### PR TITLE
chore: v1.2.1 — ML-DSA-65 only, Ed25519 removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,3 +144,15 @@ All notable changes to rcan-py are documented here.
 - Exception hierarchy: RCANError and subclasses
 - `rcan-validate` CLI: message, config, audit, uri, all subcommands
 - `py.typed` marker for mypy compatibility
+
+## v1.2.1 (2026-03-27)
+
+### Breaking Changes
+- **Ed25519 fully removed** — `KeyPair` class raises `DeprecationWarning` and redirects to `MLDSAKeyPair`
+- **`pq_sig` field removed** from wire format — `signature` field is now the sole ML-DSA-65 block
+- **`sign_message()` simplified** — takes `(msg, mldsa_keypair)`, no `pq_keypair` kwarg
+- **`verify_message()` simplified** — takes `(msg, trusted: list[MLDSAKeyPair])`, no `require_pq` kwarg
+
+### Summary
+Clean ML-DSA-65-only release. Bob (RRN-000000000001) is the first robot running this stack.
+Q-Day timeline: ML-DSA-65 primary NOW (2026), Ed25519 sunset 2027, NIST deadline 2029.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rcan"
-version = "1.2.0"
+version = "1.2.1"
 description = "Official Python SDK for the RCAN robot communication protocol"
 readme = "README.md"
 license = {text = "MIT"}

--- a/rcan/version.py
+++ b/rcan/version.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 SPEC_VERSION: str = "2.2.0"
 
 # SDK version (Python package)
-SDK_VERSION: str = "1.2.0"
+SDK_VERSION: str = "1.2.1"
 
 # v2.2 feature flags
 SUPPORTED_FEATURES: frozenset[str] = frozenset(


### PR DESCRIPTION
Patch release to publish clean ML-DSA-65-only API to PyPI.

### Changes
- Ed25519 `KeyPair` removed (raises `DeprecationWarning`, redirects to `MLDSAKeyPair`)
- `pq_sig` field removed from wire format (`signature.alg = "ml-dsa-65"` is the sole field)
- `sign_message()` / `verify_message()` simplified API
- 675 tests passing