### PR TITLE
feat: add ML-DSA-65 PQC signing — pqc-hybrid-v1 profile (issue #47)

### DIFF
--- a/rcan/__init__.py
+++ b/rcan/__init__.py
@@ -162,6 +162,8 @@ from rcan.m2m import (
     RRFRevocationPoller,
     parse_m2m_peer_token,
     verify_m2m_trusted_token,
+    sign_m2m_pqc,
+    verify_m2m_pqc,
 )
 from rcan.message import (
     MessageType,
@@ -420,6 +422,36 @@ __all__ = [
     # rcan.registry — RegistryClient (requires rcan[http])
     # rcan.signing  — KeyPair, MLDSAKeyPair, sign_message, verify_message (requires rcan[crypto]; dilithium-py for ML-DSA)
     # rcan.audit    — AuditChain
+    # v2.2 — PQC crypto primitives (issue #47)
+    "MlDsaKeyPair",
+    "HybridSignature",
+    "generate_ml_dsa_keypair",
+    "sign_ml_dsa",
+    "verify_ml_dsa",
+    "sign_hybrid",
+    "verify_hybrid",
+    "encode_public_key_jwk",
+    "decode_public_key_jwk",
+    "ML_DSA_ALG",
+    "HYBRID_ALG",
+    # v2.2 — M2M PQC helpers
+    "sign_m2m_pqc",
+    "verify_m2m_pqc",
 ]
 
 from .mcp import LOA_TO_SCOPE, TOOL_LOA_REQUIREMENTS, McpClientConfig, McpServerConfig
+
+# v2.2 — PQC crypto primitives (issue #47)
+from rcan.crypto import (
+    HYBRID_ALG,
+    ML_DSA_ALG,
+    HybridSignature,
+    MlDsaKeyPair,
+    decode_public_key_jwk,
+    encode_public_key_jwk,
+    generate_ml_dsa_keypair,
+    sign_hybrid,
+    sign_ml_dsa,
+    verify_hybrid,
+    verify_ml_dsa,
+)

--- a/rcan/address.py
+++ b/rcan/address.py
@@ -205,6 +205,63 @@ class RobotURI:
         except InvalidSignature as exc:
             raise RCANAddressError(f"RURI_SIGNATURE_INVALID for {self!r}") from exc
 
+    def sign_pqc(self, keypair: "MlDsaKeyPair") -> str:
+        """Return a signed RURI string using ML-DSA-65 (``?pqc_sig=<base64url>``).
+
+        The signature covers the UTF-8 encoded path (no scheme, no query
+        string), identical to :meth:`sign` but using ML-DSA-65 instead of
+        Ed25519.
+
+        Args:
+            keypair: :class:`~rcan.crypto.MlDsaKeyPair` with private key.
+
+        Returns:
+            Signed RURI string including ``?pqc_sig=<base64url>``.
+
+        Raises:
+            RCANSignatureError: If *keypair* has no private key.
+            ImportError:        If dilithium-py is not installed.
+        """
+        import base64
+
+        from rcan.crypto import MlDsaKeyPair, sign_ml_dsa  # noqa: F401 (type check)
+
+        sig_bytes = sign_ml_dsa(keypair, self.path.encode())
+        sig_b64 = base64.urlsafe_b64encode(sig_bytes).rstrip(b"=").decode()
+        return f"{self}?pqc_sig={sig_b64}"
+
+    def verify_sig_pqc(self, pqc_sig_b64: str, keypair: "MlDsaKeyPair") -> bool:
+        """Verify an ML-DSA-65 RURI signature.
+
+        Args:
+            pqc_sig_b64: Base64url-encoded ML-DSA-65 signature (from ``?pqc_sig=``).
+            keypair:     :class:`~rcan.crypto.MlDsaKeyPair` (public key only is
+                         sufficient).
+
+        Returns:
+            True if valid.
+
+        Raises:
+            RCANAddressError: If the signature is invalid.
+            ImportError:      If dilithium-py is not installed.
+        """
+        import base64
+
+        from rcan.crypto import MlDsaKeyPair, verify_ml_dsa  # noqa: F401
+
+        try:
+            sig_bytes = base64.urlsafe_b64decode(pqc_sig_b64 + "==")
+            verify_ml_dsa(keypair.public_key_bytes, self.path.encode(), sig_bytes)
+            return True
+        except Exception as exc:
+            from rcan.exceptions import RCANSignatureError
+
+            if isinstance(exc, RCANSignatureError):
+                raise RCANAddressError(
+                    f"RURI_PQC_SIGNATURE_INVALID for {self!r}"
+                ) from exc
+            raise
+
     @classmethod
     def parse_signed(cls, uri: str) -> tuple["RobotURI", str | None]:
         """Parse a (possibly signed) RURI string.

--- a/rcan/crypto.py
+++ b/rcan/crypto.py
@@ -1,0 +1,370 @@
+"""
+rcan.crypto — Post-Quantum Cryptography primitives (ML-DSA-65).
+
+Provides ML-DSA-65 (CRYSTALS-Dilithium, NIST FIPS 204) key generation,
+signing, and verification, plus hybrid Ed25519+ML-DSA-65 support and
+JWK encoding for public key exchange.
+
+Requires dilithium-py (already a dependency for rcan[pq]):
+    pip install rcan[pq]
+
+Example::
+
+    from rcan.crypto import generate_ml_dsa_keypair, sign_ml_dsa, verify_ml_dsa
+
+    kp = generate_ml_dsa_keypair()
+    sig = sign_ml_dsa(kp, b"hello")
+    verify_ml_dsa(kp.public_key_bytes, b"hello", sig)
+
+Spec: https://rcan.dev/spec/v2.2#section-7-2
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+from rcan.exceptions import RCANSignatureError
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+ML_DSA_ALG = "ml-dsa-65"
+HYBRID_ALG = "hybrid-ed25519-ml-dsa-65"
+
+# ML-DSA-65 key/signature sizes
+ML_DSA_PK_BYTES = 1952
+ML_DSA_SK_BYTES = 4032
+ML_DSA_SIG_BYTES = 3309
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _require_mldsa() -> Any:
+    """Return the ML_DSA_65 class or raise ImportError."""
+    try:
+        from dilithium_py.ml_dsa import ML_DSA_65  # type: ignore[import]
+
+        return ML_DSA_65
+    except ImportError as exc:
+        raise ImportError(
+            "ML-DSA-65 requires the 'dilithium-py' package. "
+            "Install with: pip install rcan[pq]"
+        ) from exc
+
+
+def _require_ed25519() -> Any:
+    """Return Ed25519PrivateKey module or raise ImportError."""
+    try:
+        from cryptography.hazmat.primitives.asymmetric import ed25519
+
+        return ed25519
+    except ImportError as exc:
+        raise ImportError(
+            "Ed25519 hybrid signing requires the 'cryptography' package. "
+            "Install with: pip install cryptography"
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
+# MlDsaKeyPair
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MlDsaKeyPair:
+    """
+    An ML-DSA-65 (CRYSTALS-Dilithium, FIPS 204) key pair.
+
+    Attributes:
+        key_id:          8-char hex derived from SHA-256 of public key.
+        public_key_bytes: Raw public key bytes (1952 bytes).
+        _secret_key:     Raw private key bytes (4032 bytes). None for verify-only.
+    """
+
+    key_id: str
+    public_key_bytes: bytes
+    _secret_key: bytes | None = field(default=None, repr=False)
+
+    @property
+    def has_private_key(self) -> bool:
+        return self._secret_key is not None
+
+    def __repr__(self) -> str:
+        mode = "private+public" if self.has_private_key else "public-only"
+        return f"MlDsaKeyPair(key_id={self.key_id!r}, alg={ML_DSA_ALG!r}, {mode})"
+
+
+# ---------------------------------------------------------------------------
+# HybridSignature
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class HybridSignature:
+    """
+    Combined Ed25519 + ML-DSA-65 signature.
+
+    Both signatures cover the same message bytes. Verification requires
+    both to pass.
+
+    Attributes:
+        ed25519_sig:  Ed25519 signature bytes (64 bytes).
+        ml_dsa_sig:   ML-DSA-65 signature bytes (3309 bytes).
+        kid:          Key ID (derived from ML-DSA-65 public key).
+    """
+
+    ed25519_sig: bytes
+    ml_dsa_sig: bytes
+    kid: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "alg": HYBRID_ALG,
+            "kid": self.kid,
+            "ed25519": base64.urlsafe_b64encode(self.ed25519_sig).rstrip(b"=").decode(),
+            "ml_dsa": base64.urlsafe_b64encode(self.ml_dsa_sig).rstrip(b"=").decode(),
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> "HybridSignature":
+        alg = d.get("alg", "")
+        if alg != HYBRID_ALG:
+            raise RCANSignatureError(
+                f"Expected alg={HYBRID_ALG!r}, got {alg!r}"
+            )
+        try:
+            ed_sig = base64.urlsafe_b64decode(d["ed25519"] + "==")
+            ml_sig = base64.urlsafe_b64decode(d["ml_dsa"] + "==")
+        except (KeyError, Exception) as exc:
+            raise RCANSignatureError(f"Invalid hybrid signature dict: {exc}") from exc
+        return cls(ed25519_sig=ed_sig, ml_dsa_sig=ml_sig, kid=d.get("kid", ""))
+
+
+# ---------------------------------------------------------------------------
+# Key generation
+# ---------------------------------------------------------------------------
+
+
+def generate_ml_dsa_keypair() -> MlDsaKeyPair:
+    """Generate a new ML-DSA-65 key pair.
+
+    Returns:
+        :class:`MlDsaKeyPair` with both private and public key.
+
+    Raises:
+        ImportError: If dilithium-py is not installed.
+    """
+    ML_DSA_65 = _require_mldsa()
+    pk, sk = ML_DSA_65.keygen()
+    kid = hashlib.sha256(pk).hexdigest()[:8]
+    return MlDsaKeyPair(key_id=kid, public_key_bytes=pk, _secret_key=sk)
+
+
+# ---------------------------------------------------------------------------
+# ML-DSA-65 sign / verify
+# ---------------------------------------------------------------------------
+
+
+def sign_ml_dsa(keypair: MlDsaKeyPair, message: bytes) -> bytes:
+    """Sign *message* with ML-DSA-65.
+
+    Args:
+        keypair: :class:`MlDsaKeyPair` with private key available.
+        message: Raw bytes to sign.
+
+    Returns:
+        ML-DSA-65 signature bytes (~3309 bytes).
+
+    Raises:
+        RCANSignatureError: If the keypair has no private key.
+        ImportError:        If dilithium-py is not installed.
+    """
+    if keypair._secret_key is None:
+        raise RCANSignatureError("Cannot sign: private key not available")
+    ML_DSA_65 = _require_mldsa()
+    return ML_DSA_65.sign(keypair._secret_key, message)
+
+
+def verify_ml_dsa(public_key_bytes: bytes, message: bytes, signature: bytes) -> None:
+    """Verify an ML-DSA-65 signature.
+
+    Args:
+        public_key_bytes: Raw ML-DSA-65 public key (1952 bytes).
+        message:          The signed message bytes.
+        signature:        ML-DSA-65 signature bytes (~3309 bytes).
+
+    Raises:
+        RCANSignatureError: If the signature is invalid.
+        ImportError:        If dilithium-py is not installed.
+    """
+    ML_DSA_65 = _require_mldsa()
+    try:
+        ok = ML_DSA_65.verify(public_key_bytes, message, signature)
+    except Exception as exc:
+        raise RCANSignatureError(f"ML-DSA-65 verification error: {exc}") from exc
+    if not ok:
+        raise RCANSignatureError("ML-DSA-65 signature verification failed")
+
+
+# ---------------------------------------------------------------------------
+# Hybrid Ed25519 + ML-DSA-65 sign / verify
+# ---------------------------------------------------------------------------
+
+
+def sign_hybrid(
+    ml_dsa_keypair: MlDsaKeyPair,
+    ed25519_private_key_bytes: bytes,
+    message: bytes,
+) -> HybridSignature:
+    """Sign *message* with both Ed25519 and ML-DSA-65.
+
+    Both signatures cover the same *message* bytes. The hybrid scheme
+    provides defence-in-depth: compromising one algorithm does not break
+    the other.
+
+    Args:
+        ml_dsa_keypair:           :class:`MlDsaKeyPair` with private key.
+        ed25519_private_key_bytes: 32-byte Ed25519 private key seed.
+        message:                   Raw bytes to sign.
+
+    Returns:
+        :class:`HybridSignature`.
+
+    Raises:
+        RCANSignatureError: If either keypair has no private key.
+        ImportError:        If dilithium-py or cryptography is not installed.
+    """
+    ed25519 = _require_ed25519()
+
+    ed_private = ed25519.Ed25519PrivateKey.from_private_bytes(ed25519_private_key_bytes)
+    ed_sig = ed_private.sign(message)
+
+    ml_sig = sign_ml_dsa(ml_dsa_keypair, message)
+
+    return HybridSignature(
+        ed25519_sig=ed_sig,
+        ml_dsa_sig=ml_sig,
+        kid=ml_dsa_keypair.key_id,
+    )
+
+
+def verify_hybrid(
+    ml_dsa_public_key_bytes: bytes,
+    ed25519_public_key_bytes: bytes,
+    message: bytes,
+    hybrid_sig: HybridSignature,
+) -> None:
+    """Verify a :class:`HybridSignature` over *message*.
+
+    Both Ed25519 and ML-DSA-65 signatures must be valid.
+
+    Args:
+        ml_dsa_public_key_bytes:   Raw ML-DSA-65 public key (1952 bytes).
+        ed25519_public_key_bytes:  32-byte Ed25519 public key.
+        message:                   The signed message bytes.
+        hybrid_sig:                :class:`HybridSignature` to verify.
+
+    Raises:
+        RCANSignatureError: If either signature is invalid.
+        ImportError:        If dilithium-py or cryptography is not installed.
+    """
+    ed25519 = _require_ed25519()
+
+    # Verify Ed25519
+    try:
+        from cryptography.exceptions import InvalidSignature
+
+        ed_pub = ed25519.Ed25519PublicKey.from_public_bytes(ed25519_public_key_bytes)
+        ed_pub.verify(hybrid_sig.ed25519_sig, message)
+    except InvalidSignature as exc:
+        raise RCANSignatureError("Hybrid: Ed25519 signature verification failed") from exc
+    except Exception as exc:
+        raise RCANSignatureError(f"Hybrid: Ed25519 verification error: {exc}") from exc
+
+    # Verify ML-DSA-65
+    verify_ml_dsa(ml_dsa_public_key_bytes, message, hybrid_sig.ml_dsa_sig)
+
+
+# ---------------------------------------------------------------------------
+# JWK encoding / decoding for ML-DSA-65 public keys
+# ---------------------------------------------------------------------------
+
+
+def encode_public_key_jwk(keypair: MlDsaKeyPair) -> dict[str, str]:
+    """Encode an ML-DSA-65 public key as a JWK-like dict.
+
+    Uses the ``OKP`` key type with ``crv: ML-DSA-65`` as specified in
+    draft-ietf-cose-dilithium.
+
+    Args:
+        keypair: :class:`MlDsaKeyPair` (public key only is sufficient).
+
+    Returns:
+        Dict with ``kty``, ``crv``, ``x``, and ``kid`` fields.
+    """
+    x = base64.urlsafe_b64encode(keypair.public_key_bytes).rstrip(b"=").decode()
+    return {
+        "kty": "OKP",
+        "crv": "ML-DSA-65",
+        "x": x,
+        "kid": keypair.key_id,
+        "use": "sig",
+        "alg": ML_DSA_ALG,
+    }
+
+
+def decode_public_key_jwk(jwk: dict[str, Any]) -> MlDsaKeyPair:
+    """Decode an ML-DSA-65 JWK dict into a public-only :class:`MlDsaKeyPair`.
+
+    Args:
+        jwk: Dict as produced by :func:`encode_public_key_jwk`.
+
+    Returns:
+        Public-only :class:`MlDsaKeyPair`.
+
+    Raises:
+        RCANSignatureError: If the JWK is missing required fields or has
+                            an unexpected key type/curve.
+    """
+    kty = jwk.get("kty")
+    crv = jwk.get("crv")
+    if kty != "OKP" or crv != "ML-DSA-65":
+        raise RCANSignatureError(
+            f"Expected OKP/ML-DSA-65 JWK, got kty={kty!r} crv={crv!r}"
+        )
+    x = jwk.get("x")
+    if not x:
+        raise RCANSignatureError("JWK missing 'x' field (public key)")
+    try:
+        pk_bytes = base64.urlsafe_b64decode(x + "==")
+    except Exception as exc:
+        raise RCANSignatureError(f"Invalid base64url in JWK 'x': {exc}") from exc
+
+    kid = jwk.get("kid") or hashlib.sha256(pk_bytes).hexdigest()[:8]
+    return MlDsaKeyPair(key_id=kid, public_key_bytes=pk_bytes, _secret_key=None)
+
+
+__all__ = [
+    "ML_DSA_ALG",
+    "HYBRID_ALG",
+    "ML_DSA_PK_BYTES",
+    "ML_DSA_SK_BYTES",
+    "ML_DSA_SIG_BYTES",
+    "MlDsaKeyPair",
+    "HybridSignature",
+    "generate_ml_dsa_keypair",
+    "sign_ml_dsa",
+    "verify_ml_dsa",
+    "sign_hybrid",
+    "verify_hybrid",
+    "encode_public_key_jwk",
+    "decode_public_key_jwk",
+]

--- a/rcan/m2m.py
+++ b/rcan/m2m.py
@@ -410,6 +410,85 @@ class M2MAuthError(Exception):
     """Raised when M2M token verification fails."""
 
 
+def sign_m2m_pqc(
+    payload: "dict[str, Any]",
+    keypair: "MlDsaKeyPair",
+    *,
+    sig_field: str = "pqc_sig",
+) -> "dict[str, Any]":
+    """Sign an M2M JWT payload dict with ML-DSA-65.
+
+    Computes an ML-DSA-65 signature over the canonical JSON of *payload*
+    (all fields except *sig_field*, sorted keys, no extra whitespace) and
+    adds it as ``payload[sig_field]`` (base64url, no padding).
+
+    This is the PQC analogue of the Ed25519 ``rrf_sig`` field used by
+    ``M2M_TRUSTED`` tokens.  Both fields can coexist during the transition
+    period.
+
+    Args:
+        payload:   JWT claims dict (modified in-place and returned).
+        keypair:   :class:`~rcan.crypto.MlDsaKeyPair` with private key.
+        sig_field: Name of the field to store the signature (default: ``"pqc_sig"``).
+
+    Returns:
+        The *payload* dict with *sig_field* added/updated.
+
+    Raises:
+        RCANSignatureError: If *keypair* has no private key.
+        ImportError:        If dilithium-py is not installed.
+    """
+    from rcan.crypto import MlDsaKeyPair, sign_ml_dsa  # noqa: F401
+
+    canonical_payload = {k: v for k, v in payload.items() if k != sig_field}
+    canonical = json.dumps(
+        canonical_payload, separators=(",", ":"), sort_keys=True
+    ).encode()
+    raw_sig = sign_ml_dsa(keypair, canonical)
+    payload[sig_field] = base64.urlsafe_b64encode(raw_sig).rstrip(b"=").decode()
+    return payload
+
+
+def verify_m2m_pqc(
+    payload: "dict[str, Any]",
+    public_key_bytes: bytes,
+    *,
+    sig_field: str = "pqc_sig",
+) -> None:
+    """Verify an ML-DSA-65 M2M payload signature.
+
+    Verifies the ML-DSA-65 signature stored in ``payload[sig_field]`` over
+    the canonical JSON of *payload* (excluding *sig_field* itself).
+
+    Args:
+        payload:          JWT claims dict containing *sig_field*.
+        public_key_bytes: Raw ML-DSA-65 public key bytes (1952 bytes).
+        sig_field:        Name of the signature field (default: ``"pqc_sig"``).
+
+    Raises:
+        M2MAuthError: If the signature is missing or invalid.
+        ImportError:  If dilithium-py is not installed.
+    """
+    from rcan.crypto import verify_ml_dsa
+
+    sig_b64 = payload.get(sig_field)
+    if not sig_b64:
+        raise M2MAuthError(f"M2M payload missing '{sig_field}' field")
+
+    canonical_payload = {k: v for k, v in payload.items() if k != sig_field}
+    canonical = json.dumps(
+        canonical_payload, separators=(",", ":"), sort_keys=True
+    ).encode()
+
+    try:
+        sig_bytes = base64.urlsafe_b64decode(sig_b64 + "==")
+        verify_ml_dsa(public_key_bytes, canonical, sig_bytes)
+    except Exception as exc:
+        raise M2MAuthError(
+            f"M2M ML-DSA-65 signature verification failed: {exc}"
+        ) from exc
+
+
 __all__ = [
     "M2MPeerClaims",
     "M2MTrustedClaims",
@@ -417,5 +496,7 @@ __all__ = [
     "M2M_TRUSTED_ISSUER",
     "parse_m2m_peer_token",
     "verify_m2m_trusted_token",
+    "sign_m2m_pqc",
+    "verify_m2m_pqc",
     "RRFRevocationPoller",
 ]

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1,0 +1,381 @@
+"""
+Tests for rcan.crypto — ML-DSA-65 PQC primitives (issue #47).
+"""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from rcan.crypto import (
+    HYBRID_ALG,
+    ML_DSA_ALG,
+    ML_DSA_PK_BYTES,
+    ML_DSA_SIG_BYTES,
+    ML_DSA_SK_BYTES,
+    HybridSignature,
+    MlDsaKeyPair,
+    decode_public_key_jwk,
+    encode_public_key_jwk,
+    generate_ml_dsa_keypair,
+    sign_hybrid,
+    sign_ml_dsa,
+    verify_hybrid,
+    verify_ml_dsa,
+)
+from rcan.exceptions import RCANSignatureError
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def kp() -> MlDsaKeyPair:
+    return generate_ml_dsa_keypair()
+
+
+@pytest.fixture(scope="module")
+def ed25519_keys():
+    """Return (private_bytes, public_bytes) for Ed25519 test keys."""
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+    from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+    priv = Ed25519PrivateKey.generate()
+    priv_bytes = priv.private_bytes_raw()
+    pub_bytes = priv.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+    return priv_bytes, pub_bytes
+
+
+# ---------------------------------------------------------------------------
+# MlDsaKeyPair
+# ---------------------------------------------------------------------------
+
+
+class TestMlDsaKeyPair:
+    def test_generate_sizes(self, kp):
+        assert len(kp.public_key_bytes) == ML_DSA_PK_BYTES
+        assert kp._secret_key is not None
+        assert len(kp._secret_key) == ML_DSA_SK_BYTES
+        assert len(kp.key_id) == 8
+
+    def test_has_private_key_true(self, kp):
+        assert kp.has_private_key is True
+
+    def test_has_private_key_false(self, kp):
+        pub = MlDsaKeyPair(
+            key_id=kp.key_id, public_key_bytes=kp.public_key_bytes, _secret_key=None
+        )
+        assert pub.has_private_key is False
+
+    def test_repr_private(self, kp):
+        r = repr(kp)
+        assert "MlDsaKeyPair" in r
+        assert "private+public" in r
+        assert ML_DSA_ALG in r
+
+    def test_repr_public_only(self, kp):
+        pub = MlDsaKeyPair(
+            key_id=kp.key_id, public_key_bytes=kp.public_key_bytes, _secret_key=None
+        )
+        assert "public-only" in repr(pub)
+
+    def test_key_id_deterministic(self, kp):
+        import hashlib
+
+        expected = hashlib.sha256(kp.public_key_bytes).hexdigest()[:8]
+        assert kp.key_id == expected
+
+    def test_different_keys_different_ids(self):
+        kp1 = generate_ml_dsa_keypair()
+        kp2 = generate_ml_dsa_keypair()
+        assert kp1.key_id != kp2.key_id
+
+
+# ---------------------------------------------------------------------------
+# sign_ml_dsa / verify_ml_dsa
+# ---------------------------------------------------------------------------
+
+
+class TestSignVerifyMlDsa:
+    def test_sign_returns_correct_size(self, kp):
+        sig = sign_ml_dsa(kp, b"hello")
+        assert len(sig) == ML_DSA_SIG_BYTES
+
+    def test_verify_valid(self, kp):
+        msg = b"rcan pqc test"
+        sig = sign_ml_dsa(kp, msg)
+        verify_ml_dsa(kp.public_key_bytes, msg, sig)  # should not raise
+
+    def test_verify_wrong_message(self, kp):
+        sig = sign_ml_dsa(kp, b"original")
+        with pytest.raises(RCANSignatureError):
+            verify_ml_dsa(kp.public_key_bytes, b"tampered", sig)
+
+    def test_verify_wrong_key(self, kp):
+        sig = sign_ml_dsa(kp, b"data")
+        other = generate_ml_dsa_keypair()
+        with pytest.raises(RCANSignatureError):
+            verify_ml_dsa(other.public_key_bytes, b"data", sig)
+
+    def test_verify_corrupted_sig(self, kp):
+        sig = bytearray(sign_ml_dsa(kp, b"data"))
+        sig[0] ^= 0xFF
+        with pytest.raises(RCANSignatureError):
+            verify_ml_dsa(kp.public_key_bytes, b"data", bytes(sig))
+
+    def test_sign_no_private_key_raises(self, kp):
+        pub_only = MlDsaKeyPair(
+            key_id=kp.key_id, public_key_bytes=kp.public_key_bytes, _secret_key=None
+        )
+        with pytest.raises(RCANSignatureError, match="private key"):
+            sign_ml_dsa(pub_only, b"data")
+
+    def test_empty_message(self, kp):
+        sig = sign_ml_dsa(kp, b"")
+        verify_ml_dsa(kp.public_key_bytes, b"", sig)
+
+    def test_large_message(self, kp):
+        msg = b"x" * 100_000
+        sig = sign_ml_dsa(kp, msg)
+        verify_ml_dsa(kp.public_key_bytes, msg, sig)
+
+
+# ---------------------------------------------------------------------------
+# HybridSignature
+# ---------------------------------------------------------------------------
+
+
+class TestHybridSignature:
+    def test_to_dict_roundtrip(self, kp, ed25519_keys):
+        priv_bytes, pub_bytes = ed25519_keys
+        hs = sign_hybrid(kp, priv_bytes, b"test msg")
+        d = hs.to_dict()
+        assert d["alg"] == HYBRID_ALG
+        assert d["kid"] == kp.key_id
+        hs2 = HybridSignature.from_dict(d)
+        assert hs2.ed25519_sig == hs.ed25519_sig
+        assert hs2.ml_dsa_sig == hs.ml_dsa_sig
+
+    def test_from_dict_wrong_alg(self):
+        d = {"alg": "wrong", "kid": "abc", "ed25519": "AAAA", "ml_dsa": "AAAA"}
+        with pytest.raises(RCANSignatureError, match="alg"):
+            HybridSignature.from_dict(d)
+
+    def test_from_dict_missing_field(self):
+        d = {"alg": HYBRID_ALG, "kid": "abc"}
+        with pytest.raises(RCANSignatureError):
+            HybridSignature.from_dict(d)
+
+
+# ---------------------------------------------------------------------------
+# sign_hybrid / verify_hybrid
+# ---------------------------------------------------------------------------
+
+
+class TestSignVerifyHybrid:
+    def test_verify_valid(self, kp, ed25519_keys):
+        priv_bytes, pub_bytes = ed25519_keys
+        msg = b"hybrid test"
+        hs = sign_hybrid(kp, priv_bytes, msg)
+        verify_hybrid(kp.public_key_bytes, pub_bytes, msg, hs)
+
+    def test_wrong_message(self, kp, ed25519_keys):
+        priv_bytes, pub_bytes = ed25519_keys
+        hs = sign_hybrid(kp, priv_bytes, b"original")
+        with pytest.raises(RCANSignatureError):
+            verify_hybrid(kp.public_key_bytes, pub_bytes, b"tampered", hs)
+
+    def test_wrong_ed25519_key(self, kp, ed25519_keys):
+        priv_bytes, pub_bytes = ed25519_keys
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+        from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+        other_priv = Ed25519PrivateKey.generate()
+        other_pub = other_priv.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+
+        hs = sign_hybrid(kp, priv_bytes, b"data")
+        with pytest.raises(RCANSignatureError, match="Ed25519"):
+            verify_hybrid(kp.public_key_bytes, other_pub, b"data", hs)
+
+    def test_wrong_ml_dsa_key(self, kp, ed25519_keys):
+        priv_bytes, pub_bytes = ed25519_keys
+        other_kp = generate_ml_dsa_keypair()
+        hs = sign_hybrid(kp, priv_bytes, b"data")
+        with pytest.raises(RCANSignatureError):
+            verify_hybrid(other_kp.public_key_bytes, pub_bytes, b"data", hs)
+
+    def test_kid_matches_ml_dsa_keypair(self, kp, ed25519_keys):
+        priv_bytes, _ = ed25519_keys
+        hs = sign_hybrid(kp, priv_bytes, b"kid test")
+        assert hs.kid == kp.key_id
+
+
+# ---------------------------------------------------------------------------
+# JWK encode / decode
+# ---------------------------------------------------------------------------
+
+
+class TestJwk:
+    def test_encode_fields(self, kp):
+        jwk = encode_public_key_jwk(kp)
+        assert jwk["kty"] == "OKP"
+        assert jwk["crv"] == "ML-DSA-65"
+        assert jwk["use"] == "sig"
+        assert jwk["alg"] == ML_DSA_ALG
+        assert jwk["kid"] == kp.key_id
+        assert "x" in jwk
+
+    def test_roundtrip(self, kp):
+        jwk = encode_public_key_jwk(kp)
+        recovered = decode_public_key_jwk(jwk)
+        assert recovered.public_key_bytes == kp.public_key_bytes
+        assert recovered.key_id == kp.key_id
+        assert not recovered.has_private_key
+
+    def test_decode_wrong_kty(self, kp):
+        jwk = encode_public_key_jwk(kp)
+        jwk["kty"] = "RSA"
+        with pytest.raises(RCANSignatureError, match="OKP"):
+            decode_public_key_jwk(jwk)
+
+    def test_decode_wrong_crv(self, kp):
+        jwk = encode_public_key_jwk(kp)
+        jwk["crv"] = "Ed25519"
+        with pytest.raises(RCANSignatureError, match="ML-DSA-65"):
+            decode_public_key_jwk(jwk)
+
+    def test_decode_missing_x(self, kp):
+        jwk = {"kty": "OKP", "crv": "ML-DSA-65", "kid": kp.key_id}
+        with pytest.raises(RCANSignatureError, match="'x'"):
+            decode_public_key_jwk(jwk)
+
+    def test_x_is_base64url_no_padding(self, kp):
+        jwk = encode_public_key_jwk(kp)
+        assert "=" not in jwk["x"]
+
+    def test_decoded_key_can_verify(self, kp):
+        jwk = encode_public_key_jwk(kp)
+        pub = decode_public_key_jwk(jwk)
+        msg = b"verify after jwk roundtrip"
+        sig = sign_ml_dsa(kp, msg)
+        verify_ml_dsa(pub.public_key_bytes, msg, sig)
+
+    def test_kid_inferred_when_missing(self, kp):
+        import hashlib
+
+        jwk = encode_public_key_jwk(kp)
+        del jwk["kid"]
+        recovered = decode_public_key_jwk(jwk)
+        expected_kid = hashlib.sha256(kp.public_key_bytes).hexdigest()[:8]
+        assert recovered.key_id == expected_kid
+
+
+# ---------------------------------------------------------------------------
+# RobotURI.sign_pqc / verify_sig_pqc integration
+# ---------------------------------------------------------------------------
+
+
+class TestRobotUriPqc:
+    URI = "rcan://registry.rcan.dev/acme/robotarm/v2/unit-001"
+
+    def test_sign_pqc_contains_param(self, kp):
+        from rcan.address import RobotURI
+
+        uri = RobotURI.parse(self.URI)
+        signed = uri.sign_pqc(kp)
+        assert "?pqc_sig=" in signed
+
+    def test_verify_sig_pqc_valid(self, kp):
+        from rcan.address import RobotURI
+
+        uri = RobotURI.parse(self.URI)
+        signed = uri.sign_pqc(kp)
+        _, _, pqc_sig = signed.partition("?pqc_sig=")
+        assert uri.verify_sig_pqc(pqc_sig, kp) is True
+
+    def test_verify_sig_pqc_wrong_key(self, kp):
+        from rcan.address import RobotURI
+        from rcan.exceptions import RCANAddressError
+
+        uri = RobotURI.parse(self.URI)
+        signed = uri.sign_pqc(kp)
+        _, _, pqc_sig = signed.partition("?pqc_sig=")
+        other_kp = generate_ml_dsa_keypair()
+        with pytest.raises(RCANAddressError, match="PQC_SIGNATURE_INVALID"):
+            uri.verify_sig_pqc(pqc_sig, other_kp)
+
+    def test_sign_pqc_no_private_key_raises(self, kp):
+        from rcan.address import RobotURI
+        from rcan.exceptions import RCANSignatureError
+
+        uri = RobotURI.parse(self.URI)
+        pub_only = MlDsaKeyPair(
+            key_id=kp.key_id, public_key_bytes=kp.public_key_bytes, _secret_key=None
+        )
+        with pytest.raises(RCANSignatureError):
+            uri.sign_pqc(pub_only)
+
+
+# ---------------------------------------------------------------------------
+# sign_m2m_pqc / verify_m2m_pqc integration
+# ---------------------------------------------------------------------------
+
+
+class TestM2MPqc:
+    def test_sign_adds_pqc_sig(self, kp):
+        from rcan.m2m import sign_m2m_pqc
+
+        payload = {"sub": "robot-001", "iss": "rrf.rcan.dev", "exp": 9999999999}
+        result = sign_m2m_pqc(payload, kp)
+        assert "pqc_sig" in result
+        assert isinstance(result["pqc_sig"], str)
+
+    def test_verify_valid(self, kp):
+        from rcan.m2m import sign_m2m_pqc, verify_m2m_pqc
+
+        payload = {"sub": "robot-001", "iss": "rrf.rcan.dev", "exp": 9999999999}
+        sign_m2m_pqc(payload, kp)
+        verify_m2m_pqc(payload, kp.public_key_bytes)  # should not raise
+
+    def test_verify_wrong_key(self, kp):
+        from rcan.m2m import M2MAuthError, sign_m2m_pqc, verify_m2m_pqc
+
+        payload = {"sub": "robot-001", "iss": "rrf.rcan.dev", "exp": 9999999999}
+        sign_m2m_pqc(payload, kp)
+        other = generate_ml_dsa_keypair()
+        with pytest.raises(M2MAuthError):
+            verify_m2m_pqc(payload, other.public_key_bytes)
+
+    def test_verify_missing_sig_field(self, kp):
+        from rcan.m2m import M2MAuthError, verify_m2m_pqc
+
+        payload = {"sub": "robot-001"}
+        with pytest.raises(M2MAuthError, match="pqc_sig"):
+            verify_m2m_pqc(payload, kp.public_key_bytes)
+
+    def test_custom_sig_field(self, kp):
+        from rcan.m2m import sign_m2m_pqc, verify_m2m_pqc
+
+        payload = {"sub": "robot-001", "exp": 9999999999}
+        sign_m2m_pqc(payload, kp, sig_field="rrf_pqc_sig")
+        assert "rrf_pqc_sig" in payload
+        verify_m2m_pqc(payload, kp.public_key_bytes, sig_field="rrf_pqc_sig")
+
+    def test_payload_mutation_breaks_sig(self, kp):
+        from rcan.m2m import M2MAuthError, sign_m2m_pqc, verify_m2m_pqc
+
+        payload = {"sub": "robot-001", "exp": 9999999999}
+        sign_m2m_pqc(payload, kp)
+        payload["sub"] = "attacker-999"  # tamper after signing
+        with pytest.raises(M2MAuthError):
+            verify_m2m_pqc(payload, kp.public_key_bytes)
+
+    def test_sign_modifies_payload_in_place(self, kp):
+        from rcan.m2m import sign_m2m_pqc
+
+        payload = {"sub": "x", "exp": 1}
+        result = sign_m2m_pqc(payload, kp)
+        assert result is payload
+        assert "pqc_sig" in payload


### PR DESCRIPTION
## Summary

Implements post-quantum cryptography primitives for rcan-py using ML-DSA-65 (NIST FIPS 204).

## New: `rcan/crypto.py`
- `MlDsaKeyPair` — dataclass with public/private key bytes
- `HybridSignature` — Ed25519 + ML-DSA-65 combined sig, encode/decode
- `generate_ml_dsa_keypair()`, `sign_ml_dsa()`, `verify_ml_dsa()`
- `sign_hybrid()`, `verify_hybrid()` — both algorithms required to pass
- `encode_public_key_jwk()`, `decode_public_key_jwk()` — OKP/ML-DSA-65 JWK format

## Updated: `rcan/address.py`
- `RobotURI.sign_pqc(keypair)` → adds `?pqc_sig=` parameter
- `RobotURI.verify_sig_pqc(sig, keypair)` → raises RCANAddressError on failure

## Updated: `rcan/m2m.py`
- `sign_m2m_pqc(payload, keypair)` — signs canonical JSON in-place
- `verify_m2m_pqc(payload, public_key_bytes)` — verifies it

## New: `tests/test_crypto.py`
42 tests covering keygen sizes, sign/verify, hybrid round-trips, tamper detection, JWK.

## Test results
723/723 passing.

Closes #47 | Part of opencastor-ops#16 implementation gate.