### PR TITLE
fix(hybrid): sign_body strips pre-existing sig field — 3.3.0 → 3.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+## [3.3.1] — 2026-04-27
+
+### Fixed
+
+- `rcan.hybrid.sign_body` now strips any pre-existing `sig` key from the body
+  before canonicalizing, mirroring `verify_body`'s long-standing behavior.
+  Bodies materialized via `dataclasses.asdict()` on a signed-envelope
+  dataclass (where `sig: dict` defaults to `{}`) previously produced
+  signatures whose canonical bytes included the empty `sig: {}` placeholder,
+  while `verify_body` reconstructed the canonical bytes without it. Hashes
+  diverged → every such signed artifact failed verification at the registry.
+  All robot-md ≥ 1.2.2 callers of FRIA / IFU / safety-benchmark /
+  incident-report / EU-register builders were affected.
+
+### Notes
+
+- Wire-format compatible with 3.3.0: a 3.3.0 signature over a body without a
+  `sig` placeholder still verifies under 3.3.1 unchanged. Only the
+  previously-unverifiable placeholder case becomes verifiable.
+- No SPEC_VERSION change. SDK_VERSION 3.3.0 → 3.3.1.
+- Existing 3.3.0-signed artifacts with the placeholder pattern will need
+  to be re-emitted with 3.3.1 to verify. Per memory's runtime-change
+  protocol, RCAN-bearing robots must re-emit + re-submit after this bump.
+
 ## [3.3.0] — 2026-04-23
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rcan"
-version = "3.3.0"
+version = "3.3.1"
 description = "Official Python SDK for the RCAN robot communication protocol"
 readme = "README.md"
 license = {text = "MIT"}

--- a/rcan/__init__.py
+++ b/rcan/__init__.py
@@ -263,7 +263,7 @@ from rcan.types import RCANAgentConfig, RCANConfig, RCANMessageEnvelope, RCANMet
 from rcan.version import SPEC_VERSION, SUPPORTED_FEATURES
 from rcan.watermark import compute_watermark_token, verify_token_format, verify_via_api
 
-__version__ = "3.3.0"
+__version__ = "3.3.1"
 __spec_version__ = "3.2"
 
 __all__ = [

--- a/rcan/hybrid.py
+++ b/rcan/hybrid.py
@@ -18,9 +18,11 @@ Wire format produced by :func:`sign_body`::
         },
     }
 
-The signature is over ``canonical_json({**body, pq_signing_pub, pq_kid})``.
-:func:`verify_body` strips only ``sig`` before re-canonicalizing, so the
-signed bytes are reconstructed exactly.
+Both :func:`sign_body` and :func:`verify_body` strip any pre-existing
+``sig`` key from the body before canonicalizing. Symmetric stripping
+ensures dataclass emitters that materialize ``sig: dict = {}`` placeholder
+fields (e.g. ``dataclasses.asdict()`` on a signed-envelope dataclass) round-
+trip cleanly.
 
 This shape is wire-compatible with RobotRegistryFoundation's
 ``functions/v2/*/register.ts`` endpoints.
@@ -76,7 +78,12 @@ def sign_body(
     """
     pq_pub_b64 = base64.b64encode(keypair.public_key_bytes).decode("ascii")
     pq_kid = _kid_from_pub(keypair.public_key_bytes)
-    body_with_ids = {**body, "pq_signing_pub": pq_pub_b64, "pq_kid": pq_kid}
+    # Strip any pre-existing `sig` field so the signed bytes match the bytes
+    # verify_body reconstructs (which always strips `sig`). Without this,
+    # callers that pass a body materialized from a dataclass with a `sig: {}`
+    # placeholder produce signatures that fail to verify.
+    body_clean = {k: v for k, v in body.items() if k != "sig"}
+    body_with_ids = {**body_clean, "pq_signing_pub": pq_pub_b64, "pq_kid": pq_kid}
     message = canonical_json(body_with_ids)
     hs = sign_hybrid(keypair, ed25519_secret, message)
     return {

--- a/rcan/hybrid.py
+++ b/rcan/hybrid.py
@@ -61,12 +61,18 @@ def sign_body(
     ``pq_kid`` (first 8 hex of sha256(pq_signing_pub)), and ``sig``
     (dict with ``ml_dsa``, ``ed25519``, ``ed25519_pub``, all base64).
 
-    The signed message is ``canonical_json({**body, pq_signing_pub,
-    pq_kid})``. :func:`verify_body` reconstructs that exact byte sequence.
+    The signed message is ``canonical_json({**body_without_sig,
+    pq_signing_pub, pq_kid})`` — any pre-existing ``sig`` field in
+    ``body`` is stripped before canonicalizing, mirroring
+    :func:`verify_body`. :func:`verify_body` reconstructs that exact
+    byte sequence. Callers may safely pass dataclass-asdict bodies that
+    include placeholder ``sig: {}`` fields; the placeholder is ignored.
 
     Args:
         keypair: ML-DSA-65 keypair. Must have ``_secret_key`` populated.
-        body: Wire body to sign. Caller retains ownership; a copy is returned.
+        body: Wire body to sign. A copy is returned with sig + pq_* added.
+            Any pre-existing ``sig`` field is stripped before canonicalizing
+            (symmetric with :func:`verify_body`).
         ed25519_secret: 32 bytes, raw Ed25519 private key.
         ed25519_public: 32 bytes, raw Ed25519 public key.
 

--- a/rcan/version.py
+++ b/rcan/version.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 SPEC_VERSION: str = "3.2"
 
 # SDK version (Python package)
-SDK_VERSION: str = "3.3.0"
+SDK_VERSION: str = "3.3.1"
 
 # v2.2 feature flags
 SUPPORTED_FEATURES: frozenset[str] = frozenset(

--- a/tests/test_hybrid.py
+++ b/tests/test_hybrid.py
@@ -86,3 +86,44 @@ def test_sign_body_pq_kid_is_first_8_hex_of_sha256(mldsa_keypair, ed25519_keypai
     )
     expected_kid = hashlib.sha256(mldsa_keypair.public_key_bytes).hexdigest()[:8]
     assert signed["pq_kid"] == expected_kid
+
+
+# ---- regression: sign_body / verify_body asymmetry on `sig` placeholder ----
+# Discovered 2026-04-27 — robot-md 1.2.2 emitters pass dataclass-asdict bodies
+# that include `sig: {}` placeholder fields. sign_body in rcan-py 3.3.0 included
+# that placeholder in the canonical bytes; verify_body strips `sig` before
+# canonicalizing. The hashes diverged → every signed artifact failed verify.
+
+def test_sign_body_strips_sig_placeholder(mldsa_keypair, ed25519_keypair):
+    """Body containing `sig: {}` placeholder must produce a verifiable signature.
+
+    This is the exact pattern robot-md FRIA/IFU/benchmarks/eu-register emit code
+    creates via dataclasses.asdict(doc) on a dataclass with `sig: dict = {}`.
+    """
+    ed_sec, ed_pub = ed25519_keypair
+    body_with_placeholder = {"hello": "world", "n": 42, "sig": {}}
+    signed = sign_body(mldsa_keypair, body_with_placeholder, ed25519_secret=ed_sec, ed25519_public=ed_pub)
+    assert verify_body(signed, base64.b64decode(signed["pq_signing_pub"])) is True
+
+
+def test_sign_body_clean_body_unchanged(mldsa_keypair, ed25519_keypair):
+    """Behavior on body without sig must be identical to pre-3.3.1 — verifies cleanly."""
+    ed_sec, ed_pub = ed25519_keypair
+    signed = sign_body(mldsa_keypair, {"hello": "world", "n": 42}, ed25519_secret=ed_sec, ed25519_public=ed_pub)
+    assert verify_body(signed, base64.b64decode(signed["pq_signing_pub"])) is True
+
+
+def test_sign_body_sig_content_irrelevant(mldsa_keypair, ed25519_keypair):
+    """The content of an existing `sig` field in body must not affect verifiability.
+
+    sign_body strips `sig` before canonicalizing, so {} vs {"garbage": "values"}
+    in body both produce signatures that verify. (The signatures themselves may
+    differ due to ML-DSA randomness — only verify success matters.)
+    """
+    ed_sec, ed_pub = ed25519_keypair
+    s1 = sign_body(mldsa_keypair, {"x": 1, "sig": {}}, ed25519_secret=ed_sec, ed25519_public=ed_pub)
+    s2 = sign_body(mldsa_keypair, {"x": 1, "sig": {"garbage": "values"}}, ed25519_secret=ed_sec, ed25519_public=ed_pub)
+    s3 = sign_body(mldsa_keypair, {"x": 1}, ed25519_secret=ed_sec, ed25519_public=ed_pub)
+    assert verify_body(s1, base64.b64decode(s1["pq_signing_pub"])) is True
+    assert verify_body(s2, base64.b64decode(s2["pq_signing_pub"])) is True
+    assert verify_body(s3, base64.b64decode(s3["pq_signing_pub"])) is True


### PR DESCRIPTION
## Summary

- One-line symmetry fix in `rcan/hybrid.py:sign_body`: strip any pre-existing `sig` key before canonicalizing, mirroring `verify_body`'s long-standing behavior.
- Bump SDK_VERSION + package version 3.3.0 → 3.3.1 (no SPEC_VERSION change).
- Makes the regression tests in `tests/test_hybrid.py` (added in 4b743fd, currently failing) pass.

## Why

Every `robot-md` ≥ 1.2.2 emitter materializes its FRIA / IFU / safety-benchmark / incident-report / EU-register documents via `dataclasses.asdict()` on dataclasses that carry `sig: dict = {}` as a default-empty placeholder. `sign_body` signed the canonical bytes *with* that empty `sig: {}` baked in; `verify_body` always stripped `sig` before reconstructing the canonical bytes. Hashes diverged by the placeholder, so the registry's verification rejected every such artifact (RRF correctly returned 401).

The fix preserves wire-compatibility for bodies without a `sig` placeholder (those signatures still verify unchanged); only the previously-unverifiable case becomes verifiable.

## Test plan

- [x] `pytest tests/test_hybrid.py` — 10/10 pass (was 7/10 on `main`)
- [x] `pytest -q` — 800/800 pass
- [x] `pytest tests/test_version.py` — version exports correct
- [ ] After merge, tag `v3.3.1` and publish to PyPI
- [ ] Re-emit Bob's signed compliance artifacts (FRIA / safety-benchmark / IFU / eu-register / incident-report) under 3.3.1 per memory's runtime-change protocol; re-submit to RRF
- [ ] Audit `continuonai/rcan-ts` for the same asymmetry; cross-language coordination per the §22-26 cascade policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)