### PR TITLE
feat(manifest): parse + soft-validate optional voice: block (rcan-spec §8.7)

### DIFF
--- a/rcan/manifest.py
+++ b/rcan/manifest.py
@@ -24,6 +24,8 @@ an ImportError with a helpful message. Install with `pip install rcan[manifest]`
 
 from __future__ import annotations
 
+import re
+import unicodedata
 import warnings
 from dataclasses import dataclass
 from pathlib import Path
@@ -120,6 +122,95 @@ def _validate_agent_runtimes(runtimes: list[dict[str, Any]]) -> list[str]:
     return errors
 
 
+# Lightweight BCP-47 sanity check — primary subtag (2-3 letters) plus optional
+# subtags. Not a full RFC 5646 validator; spec mandates soft validation.
+_BCP47_RE = re.compile(r"^[a-zA-Z]{2,3}(-[a-zA-Z0-9]+)*$")
+
+
+def _normalize_alias(s: str) -> str:
+    """Wake-word matching pre-image: NFKC + case-fold."""
+    return unicodedata.normalize("NFKC", s).casefold()
+
+
+def _validate_voice_block(voice: Any, robot_name: str | None) -> None:
+    """Soft-validate a `voice:` block per rcan-spec v3.3 §8.7.
+
+    Emits ``UserWarning`` for shape errors and the well-known soft-fail cases
+    (malformed BCP-47 language tag, alias matching robot name, NFKC-duplicate
+    aliases). Never raises — voice is fully optional and host-advisory.
+    """
+    if voice is None:
+        return
+    if not isinstance(voice, dict):
+        warnings.warn(
+            f"voice block is not a mapping (got {type(voice).__name__}); ignored",
+            UserWarning,
+            stacklevel=3,
+        )
+        return
+
+    aliases = voice.get("aliases")
+    if aliases is not None:
+        if not isinstance(aliases, list):
+            warnings.warn(
+                f"voice.aliases must be a list (got {type(aliases).__name__})",
+                UserWarning,
+                stacklevel=3,
+            )
+        else:
+            seen: dict[str, int] = {}
+            normalized_name = _normalize_alias(robot_name) if robot_name else None
+            for i, alias in enumerate(aliases):
+                if not isinstance(alias, str):
+                    warnings.warn(
+                        f"voice.aliases[{i}] is not a string (got {type(alias).__name__})",
+                        UserWarning,
+                        stacklevel=3,
+                    )
+                    continue
+                norm = _normalize_alias(alias)
+                if normalized_name and norm == normalized_name:
+                    warnings.warn(
+                        f"voice.aliases[{i}]={alias!r} duplicates robot name "
+                        f"(already a wake word); consider removing",
+                        UserWarning,
+                        stacklevel=3,
+                    )
+                if norm in seen:
+                    warnings.warn(
+                        f"voice.aliases[{i}]={alias!r} NFKC-collapses to "
+                        f"voice.aliases[{seen[norm]}] — duplicate after normalization",
+                        UserWarning,
+                        stacklevel=3,
+                    )
+                else:
+                    seen[norm] = i
+
+    lang = voice.get("language")
+    if lang is not None:
+        if not isinstance(lang, str):
+            warnings.warn(
+                f"voice.language must be a string (got {type(lang).__name__})",
+                UserWarning,
+                stacklevel=3,
+            )
+        elif not _BCP47_RE.match(lang):
+            warnings.warn(
+                f"voice.language={lang!r} does not match BCP-47 shape "
+                f"(expected e.g. 'en-US', 'pt-BR'); using as-is",
+                UserWarning,
+                stacklevel=3,
+            )
+
+    tts_voice = voice.get("tts_voice")
+    if tts_voice is not None and not isinstance(tts_voice, str):
+        warnings.warn(
+            f"voice.tts_voice must be a string (got {type(tts_voice).__name__})",
+            UserWarning,
+            stacklevel=3,
+        )
+
+
 @dataclass(frozen=True)
 class ManifestInfo:
     """Extracted identity + network fields from a ROBOT.md manifest.
@@ -132,6 +223,11 @@ class ManifestInfo:
     from the ``agent:`` block. ``None`` if the manifest has no agent block.
     Flat form is auto-normalized to a single entry (with ``DeprecationWarning``
     emitted at parse time).
+
+    ``voice`` is the optional per-rcan-spec-v3.3-§8.7 voice block as a dict:
+    ``{"aliases": [...], "language": "en-US", "tts_voice": "..."}``. ``None``
+    if the manifest has no voice block. Soft-validated at parse time —
+    obvious shape errors emit warnings but never raise.
     """
 
     rrn: str | None
@@ -142,6 +238,7 @@ class ManifestInfo:
     robot_name: str | None
     rcan_version: str | None
     agent_runtimes: list[dict[str, Any]] | None
+    voice: dict[str, Any] | None
     frontmatter: dict[str, Any]
 
 
@@ -191,16 +288,20 @@ def from_manifest(path: str | Path) -> ManifestInfo:
     if agent_runtimes is not None:
         errors = _validate_agent_runtimes(agent_runtimes)
         if errors:
-            raise ValueError(
-                "agent.runtimes[] validation failed: " + "; ".join(errors)
-            )
+            raise ValueError("agent.runtimes[] validation failed: " + "; ".join(errors))
 
     rrn = metadata.get("rrn") or None
     rcan_uri = metadata.get("rcan_uri") or None
     endpoint = network.get("rrf_endpoint") or None
     signing_alg = network.get("signing_alg") or None
     robot_name = metadata.get("robot_name") or None
-    rcan_version = str(fm["rcan_version"]) if fm.get("rcan_version") is not None else None
+    rcan_version = (
+        str(fm["rcan_version"]) if fm.get("rcan_version") is not None else None
+    )
+
+    voice_block = fm.get("voice")
+    _validate_voice_block(voice_block, robot_name)
+    voice = voice_block if isinstance(voice_block, dict) else None
 
     public_resolver = f"https://rcan.dev/r/{rrn}" if rrn else None
 
@@ -213,5 +314,6 @@ def from_manifest(path: str | Path) -> ManifestInfo:
         robot_name=robot_name,
         rcan_version=rcan_version,
         agent_runtimes=agent_runtimes,
+        voice=voice,
         frontmatter=fm,
     )

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from pathlib import Path
 
 import pytest
@@ -125,8 +126,6 @@ def test_from_manifest_scalar_frontmatter_raises(tmp_path):
 
 # --- v3.2: agent.runtimes[] normalization + validation ---
 
-import warnings
-
 
 def test_normalize_agent_flat_form_emits_deprecation_warning():
     """Flat agent.provider/model form should emit DeprecationWarning and normalize
@@ -164,12 +163,24 @@ def test_normalize_agent_runtimes_form_no_warning():
                 "id": "robot-md",
                 "harness": "claude-code",
                 "default": True,
-                "models": [{"provider": "anthropic", "model": "claude-sonnet-4-6", "role": "primary"}],
+                "models": [
+                    {
+                        "provider": "anthropic",
+                        "model": "claude-sonnet-4-6",
+                        "role": "primary",
+                    }
+                ],
             },
             {
                 "id": "opencastor",
                 "harness": "castor-default",
-                "models": [{"provider": "anthropic", "model": "claude-sonnet-4-6", "role": "primary"}],
+                "models": [
+                    {
+                        "provider": "anthropic",
+                        "model": "claude-sonnet-4-6",
+                        "role": "primary",
+                    }
+                ],
             },
         ],
     }
@@ -205,9 +216,7 @@ def test_validate_agent_runtimes_single_entry_default_optional():
     """When runtimes[] has exactly one entry, default is optional."""
     from rcan.manifest import _validate_agent_runtimes
 
-    errors = _validate_agent_runtimes(
-        [{"id": "robot-md", "harness": "claude-code"}]
-    )
+    errors = _validate_agent_runtimes([{"id": "robot-md", "harness": "claude-code"}])
     assert errors == []
 
 
@@ -317,3 +326,102 @@ def test_from_manifest_populates_agent_runtimes(tmp_path: Path):
     assert info.agent_runtimes[0]["id"] == "robot-md"
     assert info.agent_runtimes[0]["default"] is True
     assert info.agent_runtimes[1]["id"] == "opencastor"
+
+
+# ----- v3.3 §8.7 voice block --------------------------------------------------
+
+
+VOICE_MANIFEST = """\
+---
+rcan_version: '3.3'
+metadata:
+  robot_name: bob
+  rrn: RRN-000000000003
+voice:
+  aliases: [bobby, hey-bob]
+  language: en-US
+  tts_voice: en_US-amy-low
+physics:
+  type: arm
+  dof: 6
+drivers:
+  - id: arm
+    protocol: feetech
+    port: /dev/ttyACM0
+safety:
+  estop:
+    software: true
+    response_ms: 100
+network:
+  rrf_endpoint: https://rcan.dev
+---
+
+# Bob
+"""
+
+
+def test_from_manifest_populates_voice_block(tmp_path: Path):
+    """voice block parses cleanly and lands on ManifestInfo.voice."""
+    f = tmp_path / "ROBOT.md"
+    f.write_text(VOICE_MANIFEST)
+    info = from_manifest(f)
+    assert info.voice is not None
+    assert info.voice["aliases"] == ["bobby", "hey-bob"]
+    assert info.voice["language"] == "en-US"
+    assert info.voice["tts_voice"] == "en_US-amy-low"
+
+
+def test_from_manifest_no_voice_block_yields_none(tmp_path: Path):
+    """Missing voice: block → ManifestInfo.voice is None (no warnings)."""
+    f = tmp_path / "ROBOT.md"
+    f.write_text(RUNTIMES_MANIFEST)  # has no voice block
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any warning → test fails
+        info = from_manifest(f)
+    assert info.voice is None
+
+
+def test_voice_alias_duplicating_robot_name_warns(tmp_path: Path):
+    """Per §8.7 validation: alias matching robot name (after NFKC) warns, not rejects."""
+    bad = VOICE_MANIFEST.replace("aliases: [bobby, hey-bob]", "aliases: [BOB, bobby]")
+    f = tmp_path / "ROBOT.md"
+    f.write_text(bad)
+    with pytest.warns(UserWarning, match="duplicates robot name"):
+        info = from_manifest(f)
+    # Voice block still lands — validation is soft.
+    assert info.voice is not None
+    assert info.voice["aliases"] == ["BOB", "bobby"]
+
+
+def test_voice_nfkc_duplicate_aliases_warn(tmp_path: Path):
+    """Two aliases that NFKC-collapse to the same string warn (host wake-match dedup)."""
+    bad = VOICE_MANIFEST.replace("aliases: [bobby, hey-bob]", "aliases: [bobby, BOBBY]")
+    f = tmp_path / "ROBOT.md"
+    f.write_text(bad)
+    with pytest.warns(UserWarning, match="NFKC-collapses"):
+        from_manifest(f)
+
+
+def test_voice_malformed_bcp47_warns_not_rejects(tmp_path: Path):
+    """voice.language not BCP-47 shape → warning, never raise."""
+    bad = VOICE_MANIFEST.replace("language: en-US", "language: '123_not_a_lang!'")
+    f = tmp_path / "ROBOT.md"
+    f.write_text(bad)
+    with pytest.warns(UserWarning, match="BCP-47"):
+        info = from_manifest(f)
+    # Block still lands; validators consume what's there.
+    assert info.voice is not None
+    assert info.voice["language"] == "123_not_a_lang!"
+
+
+def test_voice_block_not_a_dict_is_ignored(tmp_path: Path):
+    """voice: scalar (e.g. a string) → warning + voice=None on ManifestInfo."""
+    bad = VOICE_MANIFEST.replace(
+        "voice:\n  aliases: [bobby, hey-bob]\n  language: en-US\n  tts_voice: en_US-amy-low",
+        "voice: just a string",
+    )
+    f = tmp_path / "ROBOT.md"
+    f.write_text(bad)
+    with pytest.warns(UserWarning, match="not a mapping"):
+        info = from_manifest(f)
+    assert info.voice is None


### PR DESCRIPTION
## Summary

Lands rcan-py support for the optional \`voice:\` block from rcan-spec PR continuonai/rcan-spec#198 (closing continuonai/rcan-spec#197). Block is OPTIONAL and additive — robots that omit it work unchanged. Block is parsed per §8.7 and soft-validated (warnings only, never raises).

## What lands

- \`ManifestInfo.voice: dict[str, Any] | None\` — present as raw dict when the manifest declares one. Kept opaque (no dataclass) since the schema is small and may evolve.
- \`_validate_voice_block(voice, robot_name)\` — soft validation per spec:
  - voice not a mapping → warn, return
  - aliases not a list → warn
  - alias matching robot_name (after NFKC + case-fold) → warn
  - aliases NFKC-collapsing to duplicates → warn
  - language not BCP-47 shape → warn (sanity regex, not a full RFC 5646 validator)
  - tts_voice not a string → warn
- \`_normalize_alias(s)\` — wake-word matching pre-image (NFKC + case-fold) reused by hosts that adopt this block

## Tests

23/23 manifest tests pass:
- happy path (voice block populated correctly)
- absence (voice block missing → \`None\`, no warnings)
- alias matches robot name → warn
- NFKC-duplicate aliases → warn
- malformed BCP-47 → warn (not raise)
- voice block not a dict → warn + ignored

806 total rcan-py tests pass. ruff lint + format clean.

## Strategy

Spec PR continuonai/rcan-spec#198 is still in review. Landing rcan-py support NOW (without releasing) means:

1. The spec PR's reviewers can pull this branch to validate end-to-end.
2. The moment spec #198 merges, rcan-py just needs a version bump + release — no implementation work in the critical path.
3. Soft-validation is bias-resistant against minor spec wording changes during review (the validation is per the rules already documented in §8.7's spec text, which is unlikely to change materially).

If spec #198's review surfaces a meaningfully different schema, this PR gets rebased; if not, it's ready to ship.

## Test plan

- [x] 23/23 manifest tests pass
- [x] 806/806 full suite passes
- [x] ruff lint + format clean on the changed files
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)