### PR TITLE
feat(audit-bundle): typed v1.0 helpers + verify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,37 @@
+## [3.4.0] — 2026-05-03
+
+### Added
+
+- `rcan.audit_bundle` — typed Python helpers for the audit-bundle v1.0 envelope
+  (locked in rcan-spec `schemas/audit-bundle-v1.json`, Plan 4 Task 1):
+  - `AuditBundle.new(rrn=, robot_md_sha256=, artifacts=, ...)` constructs a
+    fresh unsigned bundle with a UUID-derived `bundle_id` and ISO-8601
+    `signed_at` stamp.
+  - `Artifact` + `Signature` dataclasses for the inner nested-signature shape.
+  - `verify_bundle(bundle_json, mode=, kid_to_pem=)` returns a typed
+    `BundleVerificationResult` with per-artifact + outer-signature verdicts.
+    `mode=VerifyMode.STRICT` walks every inner artifact against its registered
+    kid; `mode=VerifyMode.AGGREGATOR_TRUST` checks only the outer signature.
+  - `kid_to_pem` accepts either a `dict[str, bytes]` or a callable
+    `(kid) -> bytes | None` so callers can plug their own resolver (RRF
+    lookup, local cache, etc).
+  - `hash_robot_md(content)` computes the canonical
+    `robot_md_sha256` field used in the bundle header.
+- `rcan.encoding.canonical_json(body, *, exclude=None)` — additive `exclude`
+  kwarg drops a top-level field before serializing. Used by audit-bundle and
+  any nested-signature scheme where the signature must not cover itself. All
+  existing callers continue to work unchanged (default `exclude=None`).
+  `rcan.audit_bundle.canonical_json` re-exports this — single source of truth
+  for cross-language byte parity (the rcan-ts whole-number-float
+  normalization landed in 3.3.2 carries through).
+
+### Notes
+
+- No SPEC_VERSION change. SDK_VERSION 3.3.3 → 3.4.0 (minor — new public API).
+- `verify_bundle` requires the `[crypto]` extra (`pip install rcan[crypto]`);
+  imports are deferred so construction-only callers do not need
+  `cryptography`.
+
 ## [3.3.3] — 2026-04-28
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rcan"
-version = "3.3.3"
+version = "3.4.0"
 description = "Official Python SDK for the RCAN robot communication protocol"
 readme = "README.md"
 license = {text = "MIT"}

--- a/rcan/__init__.py
+++ b/rcan/__init__.py
@@ -263,7 +263,7 @@ from rcan.types import RCANAgentConfig, RCANConfig, RCANMessageEnvelope, RCANMet
 from rcan.version import SPEC_VERSION, SUPPORTED_FEATURES
 from rcan.watermark import compute_watermark_token, verify_token_format, verify_via_api
 
-__version__ = "3.3.3"
+__version__ = "3.4.0"
 __spec_version__ = "3.2"
 
 __all__ = [

--- a/rcan/audit_bundle.py
+++ b/rcan/audit_bundle.py
@@ -1,0 +1,239 @@
+"""Audit-bundle v1.0 — construction + verification helpers.
+
+Implements the nested-signature envelope from rcan-spec
+``schemas/audit-bundle-v1.json``. Reuses :func:`rcan.encoding.canonical_json`
+for cross-language byte parity (the ``exclude`` kwarg drops the signature
+field before serializing the pre-image).
+
+Verification requires the ``[crypto]`` extra::
+
+    pip install rcan[crypto]
+
+Construction (``AuditBundle.new`` / ``Artifact`` / ``Signature`` /
+:func:`canonical_json` / :func:`hash_robot_md`) has no third-party
+dependencies — it works on a base ``rcan`` install.
+"""
+
+from __future__ import annotations
+
+import enum
+import hashlib
+import json
+import secrets
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Callable, Union
+
+from rcan.encoding import canonical_json
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "Signature",
+    "Artifact",
+    "AuditBundle",
+    "VerifyMode",
+    "ArtifactVerificationResult",
+    "BundleVerificationResult",
+    "verify_bundle",
+    "canonical_json",
+    "hash_robot_md",
+]
+
+SCHEMA_VERSION = "1.0"
+
+KidResolver = Union[dict[str, bytes], Callable[[str], bytes | None]]
+
+
+@dataclass
+class Signature:
+    kid: str
+    alg: str  # always "Ed25519" in v1.0
+    sig: str  # base64
+
+    def to_dict(self) -> dict:
+        return {"kid": self.kid, "alg": self.alg, "sig": self.sig}
+
+
+@dataclass
+class Artifact:
+    artifact_type: str
+    schema_version: str
+    produced_at: str
+    payload: dict
+    artifact_signature: Signature
+
+    def to_dict(self) -> dict:
+        return {
+            "artifact_type": self.artifact_type,
+            "schema_version": self.schema_version,
+            "produced_at": self.produced_at,
+            "payload": self.payload,
+            "artifact_signature": self.artifact_signature.to_dict(),
+        }
+
+
+@dataclass
+class AuditBundle:
+    bundle_id: str
+    rrn: str
+    robot_md_sha256: str
+    signed_at: str
+    matrix_version: str = "1.0"
+    matrix_signed_at: str | None = None
+    operator: dict | None = None
+    artifacts: list[Artifact] = field(default_factory=list)
+    bundle_signature: Signature | None = None
+
+    @classmethod
+    def new(
+        cls,
+        *,
+        rrn: str,
+        robot_md_sha256: str,
+        artifacts: list[Artifact],
+        operator: dict | None = None,
+        matrix_signed_at: str | None = None,
+    ) -> "AuditBundle":
+        return cls(
+            bundle_id="bundle_" + secrets.token_hex(16),
+            rrn=rrn,
+            robot_md_sha256=robot_md_sha256,
+            signed_at=datetime.now(tz=timezone.utc).isoformat(),
+            matrix_signed_at=matrix_signed_at,
+            operator=operator,
+            artifacts=artifacts,
+        )
+
+    def to_dict(self) -> dict:
+        out: dict = {
+            "schema_version": SCHEMA_VERSION,
+            "bundle_id": self.bundle_id,
+            "rrn": self.rrn,
+            "robot_md_sha256": self.robot_md_sha256,
+            "signed_at": self.signed_at,
+            "matrix_version": self.matrix_version,
+            "artifacts": [a.to_dict() for a in self.artifacts],
+        }
+        if self.matrix_signed_at:
+            out["matrix_signed_at"] = self.matrix_signed_at
+        if self.operator:
+            out["operator"] = self.operator
+        if self.bundle_signature:
+            out["bundle_signature"] = self.bundle_signature.to_dict()
+        return out
+
+
+class VerifyMode(enum.Enum):
+    STRICT = "strict"  # verify every inner artifact + bundle
+    AGGREGATOR_TRUST = "aggregator_trust"  # verify only the outer bundle signature
+
+
+@dataclass
+class ArtifactVerificationResult:
+    artifact_type: str
+    kid: str
+    ok: bool
+    reason: str
+
+
+@dataclass
+class BundleVerificationResult:
+    bundle_signature_ok: bool
+    artifact_results: list[ArtifactVerificationResult]
+    all_ok: bool
+
+
+def verify_bundle(
+    bundle_json: str,
+    *,
+    mode: VerifyMode,
+    kid_to_pem: KidResolver,
+) -> BundleVerificationResult:
+    """Verify a bundle. ``kid_to_pem`` resolves a kid to its PEM public key.
+
+    Accepts either a dict ``{kid: pem_bytes}`` or a callable
+    ``(kid) -> pem_bytes | None``. Requires the ``[crypto]`` extra.
+    """
+    data = json.loads(bundle_json)
+    bundle_sig = data.get("bundle_signature")
+    if not bundle_sig:
+        return BundleVerificationResult(
+            bundle_signature_ok=False,
+            artifact_results=[],
+            all_ok=False,
+        )
+
+    bundle_ok = _verify_signature(
+        canonical_json(data, exclude="bundle_signature"),
+        bundle_sig,
+        kid_to_pem,
+    )
+
+    artifact_results: list[ArtifactVerificationResult] = []
+    if mode == VerifyMode.STRICT:
+        for art in data.get("artifacts", []):
+            sig = art.get("artifact_signature")
+            ok = _verify_signature(
+                canonical_json(art, exclude="artifact_signature"),
+                sig,
+                kid_to_pem,
+            )
+            artifact_results.append(
+                ArtifactVerificationResult(
+                    artifact_type=art.get("artifact_type", "(unknown)"),
+                    kid=sig["kid"] if sig else "(none)",
+                    ok=ok,
+                    reason="ok" if ok else "signature did not verify",
+                )
+            )
+
+    all_ok = bundle_ok and all(r.ok for r in artifact_results)
+    return BundleVerificationResult(
+        bundle_signature_ok=bundle_ok,
+        artifact_results=artifact_results,
+        all_ok=all_ok,
+    )
+
+
+def _verify_signature(
+    message: bytes, sig_obj: dict | None, kid_to_pem: KidResolver
+) -> bool:
+    try:
+        import base64
+
+        from cryptography.exceptions import InvalidSignature
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+    except ImportError as exc:  # pragma: no cover
+        raise ImportError(
+            "rcan.audit_bundle.verify_bundle requires the [crypto] extra: "
+            "pip install rcan[crypto]"
+        ) from exc
+
+    if sig_obj is None:
+        return False
+    kid = sig_obj.get("kid")
+    if kid is None:
+        return False
+    if isinstance(kid_to_pem, dict):
+        pem = kid_to_pem.get(kid)
+    else:
+        pem = kid_to_pem(kid)
+    if pem is None:
+        return False
+    try:
+        pub = serialization.load_pem_public_key(pem)
+    except ValueError:
+        return False
+    if not isinstance(pub, Ed25519PublicKey):
+        return False
+    try:
+        pub.verify(base64.b64decode(sig_obj["sig"]), message)
+    except (InvalidSignature, KeyError, ValueError):
+        return False
+    return True
+
+
+def hash_robot_md(content: bytes) -> str:
+    """Compute the ``robot_md_sha256`` field for a given ROBOT.md body."""
+    return hashlib.sha256(content).hexdigest()

--- a/rcan/encoding.py
+++ b/rcan/encoding.py
@@ -41,7 +41,7 @@ def _normalize_for_canonical(v: Any) -> Any:
     return v
 
 
-def canonical_json(body: dict[str, Any]) -> bytes:
+def canonical_json(body: dict[str, Any], *, exclude: str | None = None) -> bytes:
     """Return the canonical UTF-8 bytes of ``body``.
 
     Deterministic: calling this twice on equivalent inputs yields identical
@@ -55,6 +55,10 @@ def canonical_json(body: dict[str, Any]) -> bytes:
 
     Args:
         body: A dict serializable by :func:`json.dumps`. Keys MUST be strings.
+        exclude: If set, a top-level key to drop from ``body`` before
+            serializing. Used by audit-bundle / nested-envelope signing where
+            the signature field must not cover itself. Only affects top-level
+            keys; nested occurrences are preserved.
 
     Returns:
         Bytes (UTF-8 encoded).
@@ -64,7 +68,11 @@ def canonical_json(body: dict[str, Any]) -> bytes:
         b'{"a":2,"b":1}'
         >>> canonical_json({"x": 50.0})
         b'{"x":50}'
+        >>> canonical_json({"a": 1, "sig": "..."}, exclude="sig")
+        b'{"a":1}'
     """
+    if exclude is not None and isinstance(body, dict):
+        body = {k: v for k, v in body.items() if k != exclude}
     return json.dumps(
         _normalize_for_canonical(body),
         sort_keys=True,

--- a/rcan/version.py
+++ b/rcan/version.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 SPEC_VERSION: str = "3.2"
 
 # SDK version (Python package)
-SDK_VERSION: str = "3.3.3"
+SDK_VERSION: str = "3.4.0"
 
 # v2.2 feature flags
 SUPPORTED_FEATURES: frozenset[str] = frozenset(

--- a/tests/test_audit_bundle.py
+++ b/tests/test_audit_bundle.py
@@ -1,0 +1,190 @@
+"""Tests for rcan.audit_bundle — construct + verify."""
+
+from __future__ import annotations
+
+import base64
+import json
+
+from rcan.audit_bundle import (
+    Artifact,
+    AuditBundle,
+    BundleVerificationResult,
+    Signature,
+    VerifyMode,
+    canonical_json,
+    hash_robot_md,
+    verify_bundle,
+)
+
+
+def test_canonical_json_is_deterministic():
+    assert canonical_json({"b": 1, "a": 2}) == b'{"a":2,"b":1}'
+    assert canonical_json({"a": [3, 1, 2]}) == b'{"a":[3,1,2]}'
+    assert canonical_json({"a": "héllo"}) == '{"a":"héllo"}'.encode("utf-8")
+
+
+def test_canonical_json_excludes_signature_field():
+    obj = {"a": 1, "signature": {"kid": "x", "alg": "Ed25519", "sig": "abc"}}
+    canon = canonical_json(obj, exclude="signature")
+    assert b"signature" not in canon
+
+
+def test_canonical_json_normalizes_whole_number_floats():
+    """Ensures the audit-bundle canonical_json shares the rcan-ts parity fix."""
+    assert canonical_json({"x": 50.0}) == b'{"x":50}'
+
+
+def test_construct_minimal_bundle():
+    bundle = AuditBundle.new(
+        rrn="RRN-000000000002",
+        robot_md_sha256="a" * 64,
+        artifacts=[],
+    )
+    payload = bundle.to_dict()
+    assert payload["schema_version"] == "1.0"
+    assert payload["rrn"] == "RRN-000000000002"
+    assert payload["bundle_id"].startswith("bundle_")
+    assert "signed_at" in payload
+
+
+def test_hash_robot_md_is_sha256_hex():
+    digest = hash_robot_md(b"# ROBOT\nname: bob\n")
+    assert len(digest) == 64
+    assert all(c in "0123456789abcdef" for c in digest)
+
+
+def test_verify_bundle_aggregator_trust_mode_with_valid_signature():
+    """A bundle signed correctly verifies in AGGREGATOR_TRUST mode."""
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    priv = Ed25519PrivateKey.generate()
+    bundle_json = _build_signed_bundle(priv, kid="test-kid")
+    pubkey_pem = _pubkey_pem(priv)
+
+    result = verify_bundle(
+        bundle_json,
+        mode=VerifyMode.AGGREGATOR_TRUST,
+        kid_to_pem={"test-kid": pubkey_pem},
+    )
+    assert result.bundle_signature_ok is True
+    assert result.all_ok is True
+
+
+def test_verify_bundle_rejects_tampered_payload():
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    priv = Ed25519PrivateKey.generate()
+    bundle_json = _build_signed_bundle(priv, kid="test-kid")
+    bundle_json = bundle_json.replace("RRN-000000000002", "RRN-000000000099")
+    pubkey_pem = _pubkey_pem(priv)
+
+    result = verify_bundle(
+        bundle_json,
+        mode=VerifyMode.AGGREGATOR_TRUST,
+        kid_to_pem={"test-kid": pubkey_pem},
+    )
+    assert result.bundle_signature_ok is False
+
+
+def test_verify_bundle_strict_mode_checks_inner_artifacts():
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    bundle_priv = Ed25519PrivateKey.generate()
+    artifact_priv = Ed25519PrivateKey.generate()
+
+    artifact = _build_signed_artifact(artifact_priv, kid="art-kid")
+    bundle_json = _build_signed_bundle(
+        bundle_priv, kid="bundle-kid", artifacts=[artifact]
+    )
+
+    kid_to_pem = {
+        "bundle-kid": _pubkey_pem(bundle_priv),
+        "art-kid": _pubkey_pem(artifact_priv),
+    }
+    result = verify_bundle(bundle_json, mode=VerifyMode.STRICT, kid_to_pem=kid_to_pem)
+    assert result.bundle_signature_ok is True
+    assert len(result.artifact_results) == 1
+    assert result.artifact_results[0].ok is True
+    assert result.all_ok is True
+
+
+def test_verify_bundle_kid_resolver_callable():
+    """kid_to_pem may be a callable, not just a dict."""
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    priv = Ed25519PrivateKey.generate()
+    bundle_json = _build_signed_bundle(priv, kid="cb-kid")
+    pubkey_pem = _pubkey_pem(priv)
+
+    def resolver(kid: str) -> bytes | None:
+        return pubkey_pem if kid == "cb-kid" else None
+
+    result = verify_bundle(
+        bundle_json, mode=VerifyMode.AGGREGATOR_TRUST, kid_to_pem=resolver
+    )
+    assert result.bundle_signature_ok is True
+
+
+def test_verify_bundle_missing_signature_returns_false():
+    bundle = AuditBundle.new(
+        rrn="RRN-000000000002",
+        robot_md_sha256="a" * 64,
+        artifacts=[],
+    )
+    payload = bundle.to_dict()
+    result = verify_bundle(
+        json.dumps(payload),
+        mode=VerifyMode.AGGREGATOR_TRUST,
+        kid_to_pem={},
+    )
+    assert isinstance(result, BundleVerificationResult)
+    assert result.bundle_signature_ok is False
+    assert result.all_ok is False
+
+
+def _build_signed_bundle(priv, *, kid: str, artifacts=None) -> str:
+    bundle = AuditBundle.new(
+        rrn="RRN-000000000002",
+        robot_md_sha256="a" * 64,
+        artifacts=artifacts or [],
+    )
+    payload = bundle.to_dict()
+    canon = canonical_json(payload, exclude="bundle_signature")
+    sig = priv.sign(canon)
+    payload["bundle_signature"] = {
+        "kid": kid,
+        "alg": "Ed25519",
+        "sig": base64.b64encode(sig).decode("ascii"),
+    }
+    return json.dumps(payload)
+
+
+def _build_signed_artifact(priv, *, kid: str) -> Artifact:
+    body = {
+        "artifact_type": "cert-gateway-authority",
+        "schema_version": "1.0",
+        "produced_at": "2026-05-03T19:00:00+00:00",
+        "payload": {"pass": 4, "fail": 0},
+    }
+    canon = canonical_json(body, exclude="artifact_signature")
+    sig = priv.sign(canon)
+    return Artifact(
+        artifact_type=body["artifact_type"],
+        schema_version=body["schema_version"],
+        produced_at=body["produced_at"],
+        payload=body["payload"],
+        artifact_signature=Signature(
+            kid=kid,
+            alg="Ed25519",
+            sig=base64.b64encode(sig).decode("ascii"),
+        ),
+    )
+
+
+def _pubkey_pem(priv) -> bytes:
+    from cryptography.hazmat.primitives import serialization
+
+    return priv.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )

--- a/tests/test_audit_bundle.py
+++ b/tests/test_audit_bundle.py
@@ -108,6 +108,35 @@ def test_verify_bundle_strict_mode_checks_inner_artifacts():
     assert result.all_ok is True
 
 
+def test_verify_bundle_strict_rejects_tampered_artifact():
+    """STRICT must catch a tampered inner artifact even when the outer
+    bundle signature is still valid."""
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    bundle_priv = Ed25519PrivateKey.generate()
+    artifact_priv = Ed25519PrivateKey.generate()
+
+    artifact = _build_signed_artifact(artifact_priv, kid="art-kid")
+    bundle_json_str = _build_signed_bundle(
+        bundle_priv, kid="bundle-kid", artifacts=[artifact]
+    )
+
+    bundle_dict = json.loads(bundle_json_str)
+    bundle_dict["artifacts"][0]["payload"]["pass"] = 999
+    tampered_json = json.dumps(bundle_dict)
+
+    kid_to_pem = {
+        "bundle-kid": _pubkey_pem(bundle_priv),
+        "art-kid": _pubkey_pem(artifact_priv),
+    }
+    result = verify_bundle(tampered_json, mode=VerifyMode.STRICT, kid_to_pem=kid_to_pem)
+
+    assert result.all_ok is False
+    assert len(result.artifact_results) == 1
+    assert result.artifact_results[0].ok is False
+    assert "did not verify" in result.artifact_results[0].reason
+
+
 def test_verify_bundle_kid_resolver_callable():
     """kid_to_pem may be a callable, not just a dict."""
     from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey


### PR DESCRIPTION
## Summary

Plan 4 Task 2. Implements the construct + verify path against the audit-bundle-v1 schema landed in [rcan-spec#208](https://github.com/continuonai/rcan-spec/pull/208) (Plan 4 Task 1).

- \`rcan.audit_bundle\` — \`AuditBundle\` / \`Artifact\` / \`Signature\` / \`VerifyMode\` / \`verify_bundle\` / \`hash_robot_md\`. Nested-signature envelope: each artifact carries its own signature, the bundle carries an aggregate signature.
- \`rcan.encoding.canonical_json\` — added optional \`exclude=\` kwarg (additive; default \`None\` so existing callers unaffected). \`audit_bundle\` re-exports it — single source of truth for cross-language byte parity. **Avoids regressing the 3.3.2 whole-number-float fix** (a separate \`canonical_json\` in \`audit_bundle\` would have silently desynced rcan-py and rcan-ts on float-valued payloads).
- \`verify_bundle\` accepts dict or callable \`kid_to_pem\` resolver. STRICT mode walks every inner artifact; AGGREGATOR_TRUST checks only the outer.
- \`cryptography\` imports deferred inside \`_verify_signature\` — construction-only callers stay on the base \`rcan\` install. \`pip install rcan[crypto]\` is required to call \`verify_bundle\`.

## Version bump

3.3.3 → **3.4.0** (minor — new public API surface). \`SDK_VERSION\`, \`__version__\`, \`pyproject.toml\` all updated. CHANGELOG entry added.

## Test plan

- [x] 10 new tests in \`tests/test_audit_bundle.py\` — canonicalization (incl. whole-number-float parity), construction, \`hash_robot_md\`, valid + tampered + missing signatures in both verify modes, callable kid resolver. All pass.
- [x] Full suite: 816 passed, 0 failed.
- [ ] CI green.

Refs spec §5 + §10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)