### PR TITLE
ci(publish): bump emit-version-tuple action @v3.2.0 → @v3.2.3

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,7 +64,7 @@ jobs:
               --generate-notes
           fi
 
-      - uses: continuonai/rcan-spec/.github/actions/emit-version-tuple@v3.2.0
+      - uses: continuonai/rcan-spec/.github/actions/emit-version-tuple@v3.2.3
         with:
           project: rcan-py
           ran: ${{ secrets.RCAN_PY_RELEASE_RAN }}
@@ -104,7 +104,7 @@ jobs:
               --generate-notes
           fi
 
-      - uses: continuonai/rcan-spec/.github/actions/emit-version-tuple@v3.2.0
+      - uses: continuonai/rcan-spec/.github/actions/emit-version-tuple@v3.2.3
         with:
           project: rcan-py
           ran: ${{ secrets.RCAN_PY_RELEASE_RAN }}


### PR DESCRIPTION
## Summary

Picks up [rcan-spec#209](https://github.com/continuonai/rcan-spec/pull/209) — \`gh release upload\` now passes \`--repo\` explicitly, so the action works in jobs without \`actions/checkout\`.

## Why

The \`publish\` job in this workflow runs without checkout (it consumes the build artifact uploaded by the \`build\` job). On the v3.4.0 release today (run \`25291383999\`), the package shipped to PyPI cleanly, then the action red-flagged the workflow at the upload step:

\`\`\`
failed to run git: fatal: not a git repository (or any of the parent directories): .git
##[error]Process completed with exit code 1.
\`\`\`

Bumping to \`v3.2.3\` fixes that. Also picks up the \`v3.2.0 → v3.2.1\` filename namespacing — the envelope file is now \`version-tuple-envelope-{field}.json\` (matches the matrix aggregator's expectation).

## Test plan

- [x] Diff is two pin updates (publish job + backfill-emit job) — same fix applied to both.
- [ ] Empirically confirmed on the next rcan-py release tag (no fake-trigger possible without a real release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)