### PR TITLE
docs(claude-md): bump CLAUDE.md version refs to current (Plan 9 carryover)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ rcan-py/
 │   ├── test_registry.py    # RegistryClient tests (mocked HTTP)
 │   ├── test_uri.py         # RobotURI parsing tests
 │   └── ...
-├── pyproject.toml          # version = "0.6.0"
+├── pyproject.toml          # name = "rcan", version = "3.4.0"
 └── CHANGELOG.md
 ```
 
@@ -39,9 +39,9 @@ rcan-py/
 ```python
 import rcan
 
-rcan.__version__       # "0.6.0"
-rcan.SPEC_VERSION      # "1.6.1"  — tracks current stable spec version
-rcan.__spec_version__  # "1.6.1"  — alias
+rcan.__version__       # "3.4.0"
+rcan.SPEC_VERSION      # "3.2"  — tracks current stable spec version
+rcan.__spec_version__  # "3.2"  — alias
 ```
 
 SPEC_VERSION is defined in `rcan/version.py` — always keep in sync with `rcan-spec` `package.json` version field. Both `__init__.py` and `message.py` re-export it.


### PR DESCRIPTION
## Summary

Plan 9 [lessons-learned](https://github.com/craigm26/opencastor-ops/blob/master/docs/superpowers/lessons-learned/2026-05-08-plan-9-execution.md) open question §4 (cross-repo CLAUDE.md drift sweep). Stale file-tree + example-output values in CLAUDE.md.

## Diff

| Line | Before | After |
|---|---|---|
| 33 | `pyproject.toml # version = "0.6.0"` | `# name = "rcan", version = "3.4.0"` |
| 42 | `rcan.__version__ # "0.6.0"` | `# "3.4.0"` |
| 43 | `rcan.SPEC_VERSION # "1.6.1"` | `# "3.2"` |
| 44 | `rcan.__spec_version__ # "1.6.1"` | `# "3.2"` |

## Verifies against

- `pyproject.toml` → `name = "rcan"`, `version = "3.4.0"`
- `rcan/version.py` → SPEC_VERSION canonical
- `curl -s https://pypi.org/pypi/rcan/json | jq -r .info.version` → `3.4.0`

## Sister PRs (same drift class)

- `craigm26/opencastor-ops` master `f9bfd1b` (direct commit)
- [craigm26/opencastor-client#132](https://github.com/craigm26/opencastor-client/pull/132)
- [craigm26/OpenCastor#896](https://github.com/craigm26/OpenCastor/pull/896)
- continuonai/rcan-ts PR (parallel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)