### PR TITLE
fix(audit-bundle): verify_bundle accepts hybrid sig shape (Ed25519+ML-DSA-65)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## [3.4.1] — 2026-05-09
+
+### Fixed
+
+- `rcan.audit_bundle.verify_bundle` now accepts the hybrid (Ed25519 + ML-DSA-65)
+  signature shape emitted by the opencastor-ops compliance-bundle aggregator —
+  `sig: {"ed25519": b64, "ml_dsa": b64, "ed25519_pub": b64}`. The Ed25519 portion
+  is verified inline; full PQC verification of the ml_dsa half remains the job
+  of `rcan.hybrid.verify_body` for callers who want both layers. Previously the
+  function raised `TypeError: argument should be a bytes-like object or ASCII
+  string, not 'dict'` against any real Plan 4/Plan 6 aggregator bundle.
+
+### Changed
+
+- `Signature.alg` is now `str | list[str]` and `Signature.sig` is now
+  `str | dict[str, str]`, matching what hybrid bundles already produce.
+
 ## [3.4.0] — 2026-05-03
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rcan"
-version = "3.4.0"
+version = "3.4.1"
 description = "Official Python SDK for the RCAN robot communication protocol"
 readme = "README.md"
 license = {text = "MIT"}

--- a/rcan/__init__.py
+++ b/rcan/__init__.py
@@ -263,7 +263,7 @@ from rcan.types import RCANAgentConfig, RCANConfig, RCANMessageEnvelope, RCANMet
 from rcan.version import SPEC_VERSION, SUPPORTED_FEATURES
 from rcan.watermark import compute_watermark_token, verify_token_format, verify_via_api
 
-__version__ = "3.4.0"
+__version__ = "3.4.1"
 __spec_version__ = "3.2"
 
 __all__ = [

--- a/rcan/audit_bundle.py
+++ b/rcan/audit_bundle.py
@@ -47,8 +47,12 @@ KidResolver = Union[dict[str, bytes], Callable[[str], bytes | None]]
 @dataclass
 class Signature:
     kid: str
-    alg: str  # always "Ed25519" in v1.0
-    sig: str  # base64
+    # "Ed25519" for the flat/v1.0 shape, or ["Ed25519", "ML-DSA-65"] for the
+    # hybrid shape emitted by the opencastor-ops aggregator.
+    alg: str | list[str]
+    # Base64 string for the flat shape, or a nested dict for hybrid:
+    # {"ed25519": b64, "ml_dsa": b64, "ed25519_pub": b64}.
+    sig: str | dict[str, str]
 
     def to_dict(self) -> dict:
         return {"kid": self.kid, "alg": self.alg, "sig": self.sig}
@@ -228,8 +232,18 @@ def _verify_signature(
     if not isinstance(pub, Ed25519PublicKey):
         return False
     try:
-        pub.verify(base64.b64decode(sig_obj["sig"]), message)
-    except (InvalidSignature, KeyError, ValueError):
+        sig_value = sig_obj["sig"]
+        if isinstance(sig_value, dict):
+            # Hybrid signature shape (Ed25519 + ML-DSA-65) emitted by the
+            # opencastor-ops aggregator: {"ed25519": b64, "ml_dsa": b64,
+            # "ed25519_pub": b64}. Verify the Ed25519 portion here; full
+            # post-quantum verification of the ml_dsa half is the job of
+            # rcan.hybrid.verify_body when the caller wants both layers.
+            sig_value = sig_value.get("ed25519")
+            if not sig_value:
+                return False
+        pub.verify(base64.b64decode(sig_value), message)
+    except (InvalidSignature, KeyError, ValueError, TypeError):
         return False
     return True
 

--- a/rcan/version.py
+++ b/rcan/version.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 SPEC_VERSION: str = "3.2"
 
 # SDK version (Python package)
-SDK_VERSION: str = "3.4.0"
+SDK_VERSION: str = "3.4.1"
 
 # v2.2 feature flags
 SUPPORTED_FEATURES: frozenset[str] = frozenset(

--- a/tests/test_audit_bundle.py
+++ b/tests/test_audit_bundle.py
@@ -154,6 +154,68 @@ def test_verify_bundle_kid_resolver_callable():
     assert result.bundle_signature_ok is True
 
 
+def test_verify_bundle_handles_hybrid_bundle_signature():
+    """Aggregator-emitted bundles use a nested sig dict (Ed25519 + ML-DSA-65)."""
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    priv = Ed25519PrivateKey.generate()
+    bundle_json = _build_signed_bundle_hybrid(priv, kid="hybrid-bundle-kid")
+    pubkey_pem = _pubkey_pem(priv)
+
+    result = verify_bundle(
+        bundle_json,
+        mode=VerifyMode.AGGREGATOR_TRUST,
+        kid_to_pem={"hybrid-bundle-kid": pubkey_pem},
+    )
+    assert result.bundle_signature_ok is True
+    assert result.all_ok is True
+
+
+def test_verify_bundle_handles_hybrid_artifact_signature_strict():
+    """STRICT mode also handles inner artifacts whose sig is the hybrid shape."""
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    bundle_priv = Ed25519PrivateKey.generate()
+    artifact_priv = Ed25519PrivateKey.generate()
+
+    artifact = _build_signed_artifact_hybrid(artifact_priv, kid="hybrid-art-kid")
+    bundle_json = _build_signed_bundle_hybrid(
+        bundle_priv, kid="hybrid-bundle-kid", artifacts=[artifact]
+    )
+
+    kid_to_pem = {
+        "hybrid-bundle-kid": _pubkey_pem(bundle_priv),
+        "hybrid-art-kid": _pubkey_pem(artifact_priv),
+    }
+    result = verify_bundle(bundle_json, mode=VerifyMode.STRICT, kid_to_pem=kid_to_pem)
+    assert result.bundle_signature_ok is True
+    assert len(result.artifact_results) == 1
+    assert result.artifact_results[0].ok is True
+    assert result.all_ok is True
+
+
+def test_verify_bundle_rejects_hybrid_sig_missing_ed25519():
+    """A hybrid sig dict that omits the ed25519 key cannot be verified."""
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    priv = Ed25519PrivateKey.generate()
+    bundle = AuditBundle.new(
+        rrn="RRN-000000000002", robot_md_sha256="a" * 64, artifacts=[]
+    )
+    payload = bundle.to_dict()
+    payload["bundle_signature"] = {
+        "kid": "hybrid-broken",
+        "alg": ["Ed25519", "ML-DSA-65"],
+        "sig": {"ml_dsa": "AAAA", "ed25519_pub": "BBBB"},  # missing ed25519
+    }
+    result = verify_bundle(
+        json.dumps(payload),
+        mode=VerifyMode.AGGREGATOR_TRUST,
+        kid_to_pem={"hybrid-broken": _pubkey_pem(priv)},
+    )
+    assert result.bundle_signature_ok is False
+
+
 def test_verify_bundle_missing_signature_returns_false():
     bundle = AuditBundle.new(
         rrn="RRN-000000000002",
@@ -206,6 +268,59 @@ def _build_signed_artifact(priv, *, kid: str) -> Artifact:
             kid=kid,
             alg="Ed25519",
             sig=base64.b64encode(sig).decode("ascii"),
+        ),
+    )
+
+
+def _build_signed_bundle_hybrid(priv, *, kid: str, artifacts=None) -> str:
+    """Build a bundle whose bundle_signature.sig is the nested hybrid shape."""
+    from cryptography.hazmat.primitives import serialization
+
+    bundle = AuditBundle.new(
+        rrn="RRN-000000000002",
+        robot_md_sha256="a" * 64,
+        artifacts=artifacts or [],
+    )
+    payload = bundle.to_dict()
+    canon = canonical_json(payload, exclude="bundle_signature")
+    sig = priv.sign(canon)
+    pub_raw = priv.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    payload["bundle_signature"] = {
+        "kid": kid,
+        "alg": ["Ed25519", "ML-DSA-65"],
+        "sig": {
+            "ed25519": base64.b64encode(sig).decode("ascii"),
+            "ml_dsa": "ZmFrZS1tbC1kc2Etc2lnbmF0dXJlLXBsYWNlaG9sZGVy",
+            "ed25519_pub": base64.b64encode(pub_raw).decode("ascii"),
+        },
+    }
+    return json.dumps(payload)
+
+
+def _build_signed_artifact_hybrid(priv, *, kid: str) -> Artifact:
+    body = {
+        "artifact_type": "cert-gateway-authority",
+        "schema_version": "1.0",
+        "produced_at": "2026-05-09T12:00:00+00:00",
+        "payload": {"pass": 4, "fail": 0},
+    }
+    canon = canonical_json(body, exclude="artifact_signature")
+    sig = priv.sign(canon)
+    return Artifact(
+        artifact_type=body["artifact_type"],
+        schema_version=body["schema_version"],
+        produced_at=body["produced_at"],
+        payload=body["payload"],
+        artifact_signature=Signature(
+            kid=kid,
+            alg=["Ed25519", "ML-DSA-65"],
+            sig={
+                "ed25519": base64.b64encode(sig).decode("ascii"),
+                "ml_dsa": "ZmFrZS1tbC1kc2Etc2lnbmF0dXJlLXBsYWNlaG9sZGVy",
+            },
         ),
     )
 


### PR DESCRIPTION
## Summary

`rcan.audit_bundle.verify_bundle` in 3.4.0 raises `TypeError` against every real opencastor-ops compliance bundle. Aggregator-emitted bundles use a nested hybrid sig:

```json
"sig": {
  "ed25519": "<b64>",
  "ml_dsa":  "<b64>",
  "ed25519_pub": "<b64>"
}
```

`_verify_signature` was calling `base64.b64decode(sig_obj["sig"])` directly — i.e. b64-decoding a dict.

This PR teaches `_verify_signature` to detect the dict shape and verify the Ed25519 portion. Full post-quantum verification of the `ml_dsa` half remains in `rcan.hybrid.verify_body` for callers who want both layers.

`Signature.alg` is now `str | list[str]` and `Signature.sig` is now `str | dict[str, str]` to reflect what hybrid bundles already produce in production.

Bump 3.4.0 → 3.4.1 (patch — bug fix, no public-API removal).

## Verification

- 3 new tests: hybrid bundle sig (AGGREGATOR_TRUST), hybrid artifact sig (STRICT), defensive case where hybrid dict is missing its ed25519 key
- `tests/test_audit_bundle.py`: **14/14 pass**
- Full suite: **820/820 pass**
- End-to-end against real `compliance-bundle-bob-2026-05-04.json` + `-v2.json` from opencastor-ops: AGGREGATOR_TRUST `bundle_signature_ok: True` (was raising TypeError before)

## Follow-up (not in this PR)

STRICT mode still fails on the artifact layer of real bundles — `cert-gateway-authority` artifact doesn't verify even though its kid resolves to the same key as the (now-passing) outer signature. That's a deeper canonicalization or aggregator-side signing-pipeline issue that should be tracked separately, likely on the opencastor-ops aggregator. The whole-number-float canonical_json fix that already landed in 3.3.2 may be a clue.

## Test plan

- [ ] `pytest tests/ -q` green on CI
- [ ] Manual: run `tests/test_audit_bundle.py::test_verify_bundle_handles_hybrid_bundle_signature` locally
- [ ] Optional regression: verify-roundtrip a fresh aggregator bundle with the new release

🤖 Generated with [Claude Code](https://claude.com/claude-code)