### PR TITLE
ci: migrate PyPI publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,15 +36,21 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     environment: pypi
+    permissions:
+      # Job-level permissions replace the workflow default, so re-declare
+      # contents:write for the `gh release create` step below.
+      contents: write
+      # Required for PyPI trusted publishing (OIDC). No PYPI_TOKEN secret needed.
+      id-token: write
     steps:
       - uses: actions/download-artifact@v4  # pinning deferred — no SHA provided
         with:
           name: dist
           path: dist/
       - name: Publish to PyPI
+        # Authenticates via OIDC trusted publishing — requires a trusted
+        # publisher configured for `rcan` in PyPI project settings.
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_TOKEN }}
 
       - name: Determine tag
         id: tag


### PR DESCRIPTION
## Context

PyPI sent a "pending trusted publisher for `rcan` expiring soon" notice. Investigation showed:

- `rcan` **already exists** on PyPI (latest `3.4.1`, 26 releases), so the *pending* publisher serves no purpose — pending publishers only matter for creating a project name that doesn't exist yet. It's safe to let it expire.
- Releases currently go out via a long-lived API token (`secrets.PYPI_TOKEN`).

This PR does the actual valuable thing the pending registration hinted at: **move off the stored token to OIDC trusted publishing** (more secure — nothing to store, rotate, or leak). This is *not* time-pressured by the 5-day expiry.

## Change

In the `publish` job of `.github/workflows/publish.yml`:
- Drop `password: ${{ secrets.PYPI_TOKEN }}` — `pypa/gh-action-pypi-publish` authenticates via OIDC.
- Add `id-token: write`.
- Re-declare `contents: write` (job-level `permissions` *replace* the workflow default, and the `gh release create` step still needs it).

## Required follow-up before next release ⚠️

This won't publish until a **regular trusted publisher** is configured for the existing `rcan` project in PyPI settings (Manage → Publishing), matching:
- Owner: `continuonai`, repo: `rcan-py`, workflow: `publish.yml`, environment: `pypi`

Note: use a *regular* trusted publisher (not the pending one) since the project already exists. Once configured, the `secrets.PYPI_TOKEN` secret can be deleted.

https://claude.ai/code/session_01VZ4rbE3uQ1kBKvg3xh8Hws

---
_Generated by [Claude Code](https://claude.ai/code/session_01VZ4rbE3uQ1kBKvg3xh8Hws)_