### PR TITLE
chore: move rcan-py to RobotRegistryFoundation + OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,14 +59,14 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          if ! gh release view "${{ steps.tag.outputs.tag }}" --repo continuonai/rcan-py >/dev/null 2>&1; then
+          if ! gh release view "${{ steps.tag.outputs.tag }}" --repo RobotRegistryFoundation/rcan-py >/dev/null 2>&1; then
             gh release create "${{ steps.tag.outputs.tag }}" \
-              --repo continuonai/rcan-py \
+              --repo RobotRegistryFoundation/rcan-py \
               --title "rcan-py ${{ steps.tag.outputs.tag }}" \
               --generate-notes
           fi
 
-      - uses: continuonai/rcan-spec/.github/actions/emit-version-tuple@v3.2.3
+      - uses: RobotRegistryFoundation/rcan-spec/.github/actions/emit-version-tuple@v3.2.3
         with:
           project: rcan-py
           ran: ${{ secrets.RCAN_PY_RELEASE_RAN }}
@@ -99,14 +99,14 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          if ! gh release view "${{ steps.tag.outputs.tag }}" --repo continuonai/rcan-py >/dev/null 2>&1; then
+          if ! gh release view "${{ steps.tag.outputs.tag }}" --repo RobotRegistryFoundation/rcan-py >/dev/null 2>&1; then
             gh release create "${{ steps.tag.outputs.tag }}" \
-              --repo continuonai/rcan-py \
+              --repo RobotRegistryFoundation/rcan-py \
               --title "rcan-py ${{ steps.tag.outputs.tag }}" \
               --generate-notes
           fi
 
-      - uses: continuonai/rcan-spec/.github/actions/emit-version-tuple@v3.2.3
+      - uses: RobotRegistryFoundation/rcan-spec/.github/actions/emit-version-tuple@v3.2.3
         with:
           project: rcan-py
           ran: ${{ secrets.RCAN_PY_RELEASE_RAN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,9 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     environment: pypi
+    permissions:
+      id-token: write   # OIDC: PyPI Trusted Publishing (no PYPI_TOKEN needed)
+      contents: write   # later steps: gh release create + emit-version-tuple
     steps:
       - uses: actions/download-artifact@v4  # pinning deferred — no SHA provided
         with:
@@ -43,8 +46,7 @@ jobs:
           path: dist/
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_TOKEN }}
+        # Trusted Publishing: OIDC token is used automatically; no password.
 
       - name: Determine tag
         id: tag

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# rcan-py — stewarded by the Robot Registry Foundation.
+# Replace with an @RobotRegistryFoundation/<team> once a maintainers team exists.
+* @craigm26

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# Contributing to rcan-py
+
+`rcan-py` is the official Python SDK for **RCAN**, an open standard stewarded by
+the [Robot Registry Foundation](https://github.com/RobotRegistryFoundation).
+
+- **SDK issues / PRs:** welcome here.
+- **Protocol / normative spec changes:** open them in
+  [`rcan-spec`](https://github.com/RobotRegistryFoundation/rcan-spec) — see its
+  governance process.
+- **Dev setup & tests:** `pip install -e ".[dev]"` then `pytest tests/ -q`
+  (see [`CLAUDE.md`](CLAUDE.md)).
+
+Keep `SPEC_VERSION` in sync with `rcan-spec`.

--- a/README.md
+++ b/README.md
@@ -179,3 +179,7 @@ Spec discussions: [github.com/RobotRegistryFoundation/rcan-spec/issues](https://
 ## License
 
 MIT
+
+---
+
+> **Stewarded by the [Robot Registry Foundation](https://github.com/RobotRegistryFoundation).** RCAN is an open standard; issues and PRs welcome. See [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![PyPI version](https://img.shields.io/pypi/v/rcan.svg)](https://pypi.org/project/rcan/)
 [![RCAN Spec](https://img.shields.io/badge/RCAN-live%20matrix-blue)](https://rcan.dev/compatibility)
-[![Tests](https://github.com/continuonai/rcan-py/actions/workflows/ci.yml/badge.svg)](https://github.com/continuonai/rcan-py/actions)
+[![Tests](https://github.com/RobotRegistryFoundation/rcan-py/actions/workflows/ci.yml/badge.svg)](https://github.com/RobotRegistryFoundation/rcan-py/actions)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue)](https://pypi.org/project/rcan/)
 
@@ -17,8 +17,8 @@ This repo is the **Python SDK** layer — the library any Python planner, gatewa
 | **Declaration** | [ROBOT.md](https://github.com/RobotRegistryFoundation/robot-md) | The file a robot ships at its root. YAML frontmatter + markdown prose. Declares identity, capabilities, safety gates. Spec + Python CLI. |
 | **Agent bridge** | [robot-md-mcp](https://github.com/RobotRegistryFoundation/robot-md-mcp) | MCP server that exposes a `ROBOT.md` to Claude Code, Claude Desktop, Cursor, Zed, Gemini CLI — any MCP-aware agent. |
 | **Wire protocol** | [RCAN](https://rcan.dev/spec/) | How robots, gateways, and planners talk. Signed envelopes, LoA enforcement, PQC crypto. Think HTTP for robots. |
-| **Python SDK** ← *this* | [rcan-py](https://github.com/continuonai/rcan-py) | `pip install rcan` — `RCANMessage`, `RobotURI`, `ConfidenceGate`, `HiTLGate`, `AuditChain`, `RegistryClient`. |
-| **TypeScript SDK** | [rcan-ts](https://github.com/continuonai/rcan-ts) | `npm install rcan-ts` — same API surface for Node + browser. |
+| **Python SDK** ← *this* | [rcan-py](https://github.com/RobotRegistryFoundation/rcan-py) | `pip install rcan` — `RCANMessage`, `RobotURI`, `ConfidenceGate`, `HiTLGate`, `AuditChain`, `RegistryClient`. |
+| **TypeScript SDK** | [rcan-ts](https://github.com/RobotRegistryFoundation/rcan-ts) | `npm install rcan-ts` — same API surface for Node + browser. |
 | **Registry** | [Robot Registry Foundation](https://robotregistryfoundation.org) | Permanent RRN identities. Public resolver at `/r/<rrn>`. Like ICANN for robots. |
 | **Reference runtime** | [OpenCastor](https://github.com/craigm26/OpenCastor) | Open-source robot runtime — connects LLM brains to hardware bodies. One implementation of RCAN. |
 
@@ -162,8 +162,8 @@ Covered sections: §1 Robot URI · §2 RBAC · §3 Message Format · §5 Authent
 | Package | Version | Purpose |
 |---|---|---|
 | **rcan-py** (this) | v2.0.0 | Python SDK |
-| [rcan-ts](https://github.com/continuonai/rcan-ts) | v2.0.0 | TypeScript SDK |
-| [rcan-spec](https://github.com/continuonai/rcan-spec) | v3.0 | Protocol spec |
+| [rcan-ts](https://github.com/RobotRegistryFoundation/rcan-ts) | v2.0.0 | TypeScript SDK |
+| [rcan-spec](https://github.com/RobotRegistryFoundation/rcan-spec) | v3.0 | Protocol spec |
 | [ROBOT.md](https://robotmd.dev) | v0.1.3 | Single-file robot manifest |
 | [OpenCastor](https://github.com/craigm26/OpenCastor) | v2026.3.17.1 | Robot runtime (reference impl) |
 | [RRF](https://robotregistryfoundation.org) | v1.6.0 | Robot identity registry |
@@ -172,9 +172,9 @@ Covered sections: §1 Robot URI · §2 RBAC · §3 Message Format · §5 Authent
 
 ## Contributing
 
-Issues and PRs welcome at [github.com/continuonai/rcan-py](https://github.com/continuonai/rcan-py).
+Issues and PRs welcome at [github.com/RobotRegistryFoundation/rcan-py](https://github.com/RobotRegistryFoundation/rcan-py).
 
-Spec discussions: [github.com/continuonai/rcan-spec/issues](https://github.com/continuonai/rcan-spec/issues)
+Spec discussions: [github.com/RobotRegistryFoundation/rcan-spec/issues](https://github.com/RobotRegistryFoundation/rcan-spec/issues)
 
 ## License
 

--- a/docs/ci-integration.md
+++ b/docs/ci-integration.md
@@ -4,7 +4,7 @@
 
 ```yaml
 - name: Validate RCAN configs
-  uses: continuonai/rcan-py/.github/actions/validate-rcan@main
+  uses: RobotRegistryFoundation/rcan-py/.github/actions/validate-rcan@main
   with:
     level: "2"
 ```
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: continuonai/rcan-py/.github/actions/validate-rcan@main
+      - uses: RobotRegistryFoundation/rcan-py/.github/actions/validate-rcan@main
         with:
           level: "1"
 ```
@@ -30,7 +30,7 @@ jobs:
 
 ```yaml
 repos:
-  - repo: https://github.com/continuonai/rcan-py
+  - repo: https://github.com/RobotRegistryFoundation/rcan-py
     rev: v0.1.0
     hooks:
       - id: rcan-validate-config

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dev = ["pytest>=8", "pytest-asyncio>=0.23", "httpx>=0.27", "cryptography>=42.0",
 
 [project.urls]
 Homepage = "https://rcan.dev"
-Repository = "https://github.com/continuonai/rcan-py"
+Repository = "https://github.com/RobotRegistryFoundation/rcan-py"
 Documentation = "https://rcan.dev/docs"
 Specification = "https://rcan.dev/spec"
 


### PR DESCRIPTION
Part of moving the RCAN trio from `continuonai` to the **Robot Registry
Foundation**. The published PyPI package stays `rcan`; only the source home and
CI trust change.

Changes:
- `ci: migrate PyPI publishing to OIDC trusted publishing` — `id-token: write`,
  drop the `PYPI_TOKEN` password, provenance via OIDC. (Requires a trusted
  publisher registered on PyPI for `RobotRegistryFoundation/rcan-py`, env `pypi`.)
- `chore(ci)`: re-point `publish.yml` (`--repo` + `emit-version-tuple` action) at
  the new owner.
- `docs`: `pyproject.toml` Repository URL, README, and `docs/ci-integration.md`
  (the `validate-rcan` action refs) re-pointed.
- Governance: `CODEOWNERS`, `CONTRIBUTING.md`, README stewardship note.

CHANGELOG untouched. Token retirement (deleting `PYPI_TOKEN`) is a separate
follow-up after a verified OIDC release.
